### PR TITLE
AB 5.7 Präzisierung der 200-Punkte-Grenze

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -242,7 +242,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Zum Meldeschluss können bis zu 15 Spieler in fester Reihenfolge gemeldet werden. Die Mannschaftsmeldung darf von der Aufstellung der Qualifikationsturnier und Landesverbandsmeisterschaften abweichen.
 
-    > Bei den Deutschen Mannschaftsmeisterschaften darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt. Über begründete Ausnahmen entscheidet der Turnierverantwortliche. Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.
+    > Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt. Über begründete Ausnahmen entscheidet der Turnierverantwortliche. Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.
 
     > In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind. Die Startrangliste kann während des Turniers nicht verändert werden. Der Turnierverantwortliche kann Ausnahmen zulassen.
 


### PR DESCRIPTION
Die Formulierung „Deutsche Mannschaftsmeisterschaft“ lässt die Interpretation zu, dass dies einzig für die Deutschen Meisterschaften für Vereinsmannschaften (DVM) gelte. Da die Regelung jedoch unter JSpO 5 („Allgemeine Bestimmungen für Mannschaftsturniere“) statt JSpO 9 („Allgemeine Bestimmungen zu den Deutschen Meisterschaften für Vereinsmannschaften“) geführt wird, beseitigt die neue Fassung derartige Zweifel. In der Praxis wird die AB zu 5.7 (2) auch bei der Deutschen Ländermeisterschaft angewandt.
