### PR TITLE
AB 8.3 Berechnung der Startrangliste zur Deutschen Ländermeisterschaft

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -353,6 +353,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Jede Mannschaft besteht in jedem Mannschaftskampf aus je einem Jugendlichen der Altersklassen U20, U18, U16, U14, U12, U20w, U16w und U12w. Es sind zwei Ersatzspieler zugelassen, von denen mindestens einer weiblich sein muss.
 
+    > Abweichend zu AB zu 5 wird die Startrangliste nach dem DWZ-Schnitt der acht höchstgesetzten Spieler gebildet, die Ziffer 8.3 Satz 1 erfüllen.
+
 1.  
     Es wird ein Turnier über sieben Runden nach Schweizer System ausgetragen.
 


### PR DESCRIPTION
Bei der Deutschen Ländermeisterschaft können Mannschaften aus bis zu zehn Spielern gemeldet werden. Da nach JSpO 5.7 diese Mannschaften nach Spielstärke aufzustellen sind, können die ersten acht Spieler zusammen jedoch mitunter so gar nicht gemeinsam antreten, da Ziffer 8.3 Satz 1 einzuhalten ist. Derzeit wird die Startrangliste des Turniers demnach mit DWZ-Schnitten gebildet, die so wenig Aussagekraft haben.
Welch hohe Auswirkung die bestehende Fassung auf den Setzlistenplatz hat, macht das folgende Beispiel der DLM 2013 deutlich:

|  | Bayern (DLM 2013) | DWZ |
| --- | --- | --- |
| 1 | Spieler U20 | 2465 |
| 2 | Spieler U18 | 2402 |
| 3 | Spieler U20 | 2401 |
| 4 | Spieler U16 | 2119 |
| 5 | Spieler U14 | 1997 |
| 6 | Spieler U18w | 1847 |
| 7 | Spieler U16w | 1832 |
| 8 | Spieler U12 | 1792 |
| 9 | Spieler U12w | 1219 |

Nach der geltenden Fassung wird der DWZ-Schnitt zur Bestimmung der Startrangliste aus den Spielern 1 bis 8 gebildet und beträgt so **2107**. Die beiden U20-Spieler an 1 und 3 dürfen in Folge von Ziffer 8.3 Satz 1 jedoch zu keinem Spiel gemeinsam eingesetzt werden. Nach der neuen Fassung würde der Schnitt daher aus den Spielern 1, 2, 4 und folgende gebildet werden und lediglich **1959** betragen. Dies beschreibt die Spielstärke der Mannschaft, die tatsächlich antreten kann, deutlich besser und sollte daher zur Bildung der Startrangliste herangezogen werden.

Die neue Fassung bezieht sich auf die acht höchstgesetzten Spieler. Unter Einhaltung der 200-Punkte-Regel aus AB zu 5.7 (2) wäre es also möglich gewesen, die Spieler 1 und 3 zu tauschen und so direkt den Startranglistenplatz zu beeinflussen, da dann 2401 statt 2465 in die Durchschnittsbildung eingegangen wäre. Da sich der DWZ-Schnitt durch solche Verdrehungen aber um maximal 25 Punkte ändern kann (maximale Differenz 200 durch Anzahl der Spieler), scheint es abwegig, dies zur Manipulation zu nutzen, da der Nachteil des tiefer eingesetzten starken Spielers sicher schwerer wiegt.

In der Praxis ist die neue Fassung jedoch zeitaufwendig: Kein Auslosungsprogramm besitzt eine entsprechende Option, sodass den Turnierleitern ein Tool gestellt werden müsste, um durch die händische Berechnung der DWZ-Schnitte vor der ersten Runde den Turnierablauf nicht unnötig zu verzögern. Dies ist auch ratsam, da der ganze Prozess fehleranfällig ist: Reisen Mannschaften mit zehn oder besonders jungen Spielern an, tritt das Problem auf, dass etwa eine U12w-Spielerin ja auch als U14, U16w, U16 usw. eingesetzt werden könnte.
Das händische Verfahren zur Bestimmung der acht höchstgesetzten Spieler einer Mannschaft, die Ziffer 8.3 Satz 1 erfüllen, ist jedoch problemlos möglich:
1. Bestimme den höchstgesetzten Spieler U12w
2. Bestimme aus den verbliebenen den höchstgesetzten Spieler U12 (inklusive U12w)
3. Bestimme aus den verbliebenen den höchstgesetzten Spieler U14 (inklusive U12w, U12)
4. entsprechend: U16w (inkl. U12w)
5. entsprechend: U16 (inkl. U12w, U12, U14, U16w)
6. entsprechend: U18 (inkl. U12w, U12, U14, U16w, U16)
7. entsprechend: U20w (inkl. U12w, U16w)
8. Bestimme den höchstgesetzten verbliebenen Spieler
