### PR TITLE
Ersatzspieler zur Deutschen Ländermeisterschaft

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -351,7 +351,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Die Mannschaft firmiert als Spielgemeinschaft beider beteiligter Länder.
 
 1.  
-    Jede Mannschaft besteht in jedem Mannschaftskampf aus je einem Jugendlichen der Altersklassen U20, U18, U16, U14, U12, U20w, U16w und U12w. Es sind zwei Ersatzspieler zugelassen, von denen mindestens einer weiblich sein muss.
+    Jede Mannschaft besteht in jedem Mannschaftskampf aus je einem Jugendlichen der Altersklassen U20, U18, U16, U14, U12, U20w, U16w und U12w. Ergänzend zu 5.8 kann ein zweiter Ersatzspieler in die Startrangliste aufgenommen werden. Von diesen zwei Ersatzspielern darf maximal einer männlich sein.
 
     > Abweichend zu AB zu 5 wird die Startrangliste nach dem DWZ-Schnitt der acht höchstgesetzten Spieler gebildet, die Ziffer 8.3 Satz 1 erfüllen.
 


### PR DESCRIPTION
# Antrag zur Jugendversammlung

> **JSpO 8.3 (geltende Fassung)**
> Jede Mannschaft besteht in jedem Mannschaftskampf aus je einem Jugendlichen der Altersklassen U20, U18, U16, U14, U12, U20w, U16w und U12w. Es sind zwei Ersatzspieler zugelassen, von denen mindestens einer weiblich sein muss.
> **JSpO 8.3 (neue Fassung)**
> Jede Mannschaft besteht in jedem Mannschaftskampf aus je einem Jugendlichen der Altersklassen U20, U18, U16, U14, U12, U20w, U16w und U12w. Ergänzend zu 5.8 kann ein zweiter Ersatzspieler in die Startrangliste aufgenommen werden. Von diesen zwei Ersatzspielern darf maximal einer männlich sein.

Die geltende Fassung von Ziffer 8.3 ist in zwei Punkten missdeutig: Zum einen wird die Abweichung von JSpO 5.8, das bei Mannschaftswettbewerben nur die Meldung eines Ersatzspielers zulässt, nicht deutlich. Zum anderen ist unklar, wie bei nur einem gemeldeten Ersatzspieler zur DLM zu verfahren ist. Der bisherige Nachsatz, „von denen mindestens einer weiblich sein muss“, ließe die Interpretation zu, dass dann der einzige Ersatzspieler weiblich sein müsse.
Da dies jedoch dem Regelungssinne widerspricht – andernfalls könnten Mannschaften eine weibliche Ersatzspielerin einzig nominieren, um einen weiteren männlichen Ersatzspieler einsetzen zu können – soll die neue Fassung Eindeutigkeit schaffen. Damit wird auch der bisherigen Auslegung Rechnung getragen, die auch jetzt schon einen einzigen männlichen Ersatzspieler zuließ.
Die Neufassung lässt weiterhin die Möglichkeit, zwei weibliche Ersatzspieler zu nominieren, da JSpO 5.8 geschlechtsneutral gefasst ist.

_Commit 06d85ab_
