### PR TITLE
Freilassen von Brettern unter Namensnennung von Nichtanwesenden

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -246,6 +246,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind. Die Startrangliste kann während des Turniers nicht verändert werden. Der Turnierverantwortliche kann Ausnahmen zulassen.
 
+    > Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
+
     > Bretter können bei Namensnennung freigelassen werden. Das letzte Brett kann ohne Namensnennung freigelassen werden.
 
 1.  


### PR DESCRIPTION
# Antrag zur Jugendversammlung

> **AB zu 5.7 (geltende Fassung)**
> Zum Meldeschluss können bis zu 15 Spieler in fester Reihenfolge gemeldet werden. Die Mannschaftsmeldung darf von der Aufstellung der Qualifikationsturnier und Landesverbandsmeisterschaften abweichen.
> 
> Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche. Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.
> 
> In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind. Die Startrangliste kann während des Turniers nicht verändert werden. Der Turnierverantwortliche kann Ausnahmen zulassen.
> 
> Bretter können bei Namensnennung freigelassen werden. Das letzte Brett kann ohne Namensnennung freigelassen werden.
> 
> **AB zu 5.7 (neue Fassung)**
> Zum Meldeschluss können bis zu 15 Spieler in fester Reihenfolge gemeldet werden. Die Mannschaftsmeldung darf von der Aufstellung der Qualifikationsturnier und Landesverbandsmeisterschaften abweichen.
> 
> Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche. Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.
> 
> In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind. Die Startrangliste kann während des Turniers nicht verändert werden. Der Turnierverantwortliche kann Ausnahmen zulassen.
> 
> Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
> 
> Bretter können bei Namensnennung freigelassen werden. Das letzte Brett kann ohne Namensnennung freigelassen werden.

Die Kombination der Ausnahmeregelung zur Aufnahme von nicht-anwesenden Spielern in die Startrangliste und die Möglichkeit des Freilassens von Bretter mit Namensnennung führt bisher zu einer Regelungslücke. Diese ermöglicht entgegen der Intention der Regelungen in bestimmten Fällen, dass vordere Bretter geplant freigelassen werden können.
Die Neuregelung schließt diese Lücke.

_Commit 74168a7_
