### PR TITLE
Ergänzung zu AB 9.4: Berechnung DVM-Kontingente U14/U14w in Folge Abbruch 2013

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -409,6 +409,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Sollte eine Regionalgruppe danach keinen Platz oder nur den Ausrichterfreiplatz zugeteilt bekommen, so erhält diese Regionalgruppe einen Platz, der von den nach der Rest-Verteilung zu vergebenden Plätzen abgezogen wird.
     >
     > Sollte nach der Verteilung Gleichheit bei dem letzten zu vergebenden Platz entstehen, so geht dieser Platz an die Regionalgruppe, die die bestplatzierte Mannschaft des Vorjahres aufzuweisen hat.
+    >
+    > *In Folge der abgebrochenen DVM 2013 der Altersklassen U14 und U14w wird wie folgt verfahren: Jede Mannschaft wird mit der Mannschaftspunktzahl nach der vierten Runde, erhöht um drei, herangezogen. Erzielt eine Mannschaft im U14w-Fortsetzungsturnier in den verbliebenen drei Runden mehr als drei Mannschaftspunkte, werden ihr stattdessen diese Punkte gutgeschrieben.*
 
 1.  
     Bei jeder Deutschen Meisterschaft für Vereinsmannschaften ist grundsätzlich nur eine Mannschaft pro Verein startberechtigt.


### PR DESCRIPTION
# Berechnung der DVM-Kontingente U14 & U14w in Folge des Abbruchs 2013

In Folge der im Dezember 2013 abgebrochenen Deutschen Vereinsmeisterschaften der Altersklassen U14 und U14w muss das Berechnungsverfahren der Teilnehmerplätze für die Folgejahre angepasst werden. Die derzeit in den Ausführungsbestimmungen (AB) der Jugendspielordnung (JSpO) gefasste Berechnungsregel sorgt dafür, dass die Hälfte der Teilnehmerplätze anhand der Resultate der Vorjahre vergeben wird. Durch den Abbruch nach vier Runden sind die Turniere der U14 und U14w jedoch nicht mit den Vorjahren vergleichbar.
## Derzeitige Berechnungsformel

Die Formel zur Berechnung der DVM-Kontingente ist in AB zu JSpO 9.4 festgelegt:

> **Auszug aus den AB zu 9.4:**
> Die Hälfte der nach Abzug der Ausrichterfreiplätze zu vergebenden Plätze einer Meisterschaft wird nach der Anzahl der gemeldeten Jugendlichen auf die Regionalgruppen verteilt (Quantität), die andere Hälfte wird nach den Ergebnissen der letzten drei Jahre auf die Regionalgruppen verteilt (Qualität). Das Auf- und Abrunden der Teilnehmerzahlen erfolgt nach der Addition der beiden Kriterien.
> (…)
> Zur Vergabe der nach den Ergebnissen der Vorjahre zu verteilenden Plätze werden die Durchschnittsmannschaftspunktzahlen (DMP) der teilnehmenden Mannschaften für jede Regionalgruppe für die jeweilige Altersklasse für die vergangenen drei Jahre ermittelt. Dabei werden die Punktzahlen der letzten beiden Jahre verdoppelt. Bei der Berechnung der DMP wird in der Regionalgruppe, die jeweils den Ausrichter gestellt hat, das Ergebnis der im jeweiligen Jahr schlechtesten Mannschaft nicht berücksichtigt, sofern der Ausrichtervertreter nicht einziger Teilnehmer aus dieser Regionalgruppe war. Die Summe dieser Punktzahlen bildet (für jede Regionalgruppe und jede Altersklasse) die Grundlage für die Verteilung der Plätze nach dem Verfahren Hare/Niemeyer.

Die aufgrund des Abbruches geringere Höhe der Mannschaftspunktzahlen zur DVM 2013 in den Altersklassen U14 und U14w wird sich also direkt auf die Berechnung der Kontingente zu den DVM der Jahre 2014 bis 2016 auswirken. Zwar sind alle Regionalgruppen gleichermaßen vom kürzeren Turnier betroffen, dennoch sind die Mannschaftspunktzahlen nicht mit jenen normaler Jahre zu vergleichen, insofern muss ein Ausgleich stattfinden.
## Kriterien zur Anpassung der Ergebnisse der DVM U14 & U14w 2013

Bei den DVM U14 und U14w 2013 wurden nur vier der angesetzten sieben Runden ausgespielt.
Eine Anpassung der Berechnungsformel zum Ausgleich des Abbruches 2013 muss folgende Punkte berücksichtigen:
- Regionalgruppen, deren Vereine im Schnitt mehr Punkte holten als die anderer, sollen auch bei der Berechnung im Vorteil sein.
- Extremergebnisse, die nach vier Runden noch eher auftreten als nach sieben, sollen keine so starke Gewichtung haben wie bei einem vollständig ausgespielten Turnier.
- Auf die Plätze der Regionalgruppen soll sich nicht direkt auswirken, ob einzelne Vereine am Fortsetzungsturnier U14w im Sommer 2014 teilnehmen oder nicht.

Die drei ausstehenden Runden der DVM U14w werden im Sommer 2014 nachgespielt, wobei nicht alle ursprünglichen Vereine am Fortsetzungsturnier teilnehmen. Weil dies eine weitere besondere Situation darstellt, soll die DVM U14, welche keine Fortsetzung findet, zuerst betrachtet werden.
## Angepasste Berechnungsformel DVM U14

Die offensichtliche Möglichkeit, die Ergebnisse der abgebrochenen DVM U14 mit dem Faktor 7/4 zu multiplizieren, benachteiligt stark jene Regionalgruppen, deren Vertreter nach vier Runden nur wenige Mannschaftspunkte aufwiesen. Andererseits werden Mannschaften, die nach vier Runden noch acht oder sieben Mannschaftspunkte hatten, stark bevorteilt.
Auch die Möglichkeit, die Meisterschaften U14 und U14w des Jahres 2013 für die Kontingentberechnung gänzlich unberücksichtigt zu lassen und entweder stattdessen die beiden Vorjahre hinzuzuziehen oder die Berechnung so anzupassen, dass nur zwei statt drei Vorjahresergebnisse berücksichtigt werden, schafft keine größere Vergleichbarkeit: Nach vier Runden liegen bereits Ergebnisse zwischen den Regionalgruppen vor, die dann unberücksichtigt blieben.
Stattdessen wird analog zur Buchholzberechnung bei zurückgetretenen Mannschaften verfahren: Für jede noch ausstehende Runde wird ein Mannschaftsremis zugrunde gelegt, d.h. alle Mannschaften werden für die Kontingentberechnung mit drei weiteren Mannschaftspunkten bedacht. Die Durchschnittsmannschaftspunktzahl (DMP) wird also schlicht um drei erhöht. Dies sorgt für Vergleichbarkeit mit den anderen Jahren, erhält die Abstände der bisherigen Tabelle und vermeidet jene Extremergebnisse.
## Angepasste Berechnungsformel DVM U14w

Grundsätzlich wird die Altersklasse U14w genauso behandelt wie die U14, auch wenn noch ein Fortsetzungsturnier über die verbliebenen drei Runden stattfindet. Erst einmal fließt in die Berechnung der U14w-Kontingente also die Mannschaftspunktzahl nach der vierten Runde, jeweils erhöht um drei, ein.
Sollte ein Verein nach dem Fortsetzungsturnier jedoch eine höhere Mannschaftspunktzahl aufweisen, d.h. in den verbliebenen drei Runden mehr als drei Mannschaftspunkte erzielen, wird stattdessen diese Zahl herangezogen. Erspielt ein Verein weniger als drei Mannschaftspunkte, bleibt das Ergebnis des Fortsetzungsturniers unbedacht. Dadurch wird vermieden, dass Regionalgruppen, deren Vereine beim Fortsetzungsturnier teilnehmen, aber schlecht abschneiden, schlechter gestellt sind als jene, deren Vereine ihre Teilnahme abgesagt haben.
## Antrag zur Änderung der Ausführungsbestimmungen

Die Ausführungsbestimmung zu JSpO 9.4 wird um folgenden redaktionellen Hinweis ergänzt:

> **Redaktioneller Hinweis zu AB zu 9.4 (Ergänzung):**
> In Folge der abgebrochenen DVM 2013 der Altersklassen U14 und U14w wird wie folgt verfahren: Jede Mannschaft wird mit der Mannschaftspunktzahl nach der vierten Runde, erhöht um drei, herangezogen. Erzielt eine Mannschaft im U14w-Fortsetzungsturnier in den verbliebenen drei Runden mehr als drei Mannschaftspunkte, werden ihr stattdessen diese Punkte gutgeschrieben.
