### PR TITLE
Anpassung an FR'14, AB 2.1: Mitbringen von elektronischen Geräten

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -73,7 +73,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Gemäß Art. 9.1 lit. a der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
 
-    > Abweichend von Art. 7.5 lit. b der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5 lit. b der FIDE-Regeln ist analog auf den zweiten regelwidrigen Zug anzuwenden.
+    > Abweichend von Art. 7.5 lit. b und Anhang A4 lit. b der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5 lit. b der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
 
 1.  
     Der Schiedsrichter berücksichtigt bei der Anwendung der FIDE-Regeln den Entwicklungsstand des Spielers und kann in begründeten Ausnahmefällen im Sinne einer altersgemäßen Handhabung von einzelnen Regeln abweichende Entscheidungen treffen.


### PR DESCRIPTION
Die zum 01.07.2014 aktualisierten [FIDE-Regeln](http://srk.schachbund.de/nachrichtenleser-der-srk/deutsche-uebersetzung-der-fide-regeln.html?file=files/dsb/ordnung/FIDERegeln2014-eng.pdf) machen in AB 2.1 folgende Änderungen nötig:
- Die Referenz auf FR 12.3 wird durch 11.3 ersetzt. [d8a0b6f]
- Abweichend zu FR 11.3 führt das Mitbringen eines elektronischen Kommunikationsgerätes nicht automatisch zum Partieverlust. Stattdessen wird der Strafenkatalog in JSpO 3.1 angewendet. [b47c230]
- Abweichend zu FR 7.5 lit. b führt erst der dritte regelwidrige Zug zum Partieverlust. [47c001e]

Die Diskussion und Abstimmung im Arbeitskreis Spielbetrieb steht noch aus.
