### PR TITLE
Referenz in AB 3.1 auf FIDE-Regel 12.9 (vorher: 13.4) korrigiert

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -131,7 +131,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     1.  Ausschluss von der laufenden Veranstaltung,
     1.  Anordnung, die Unterkunft zu verlassen.
 
-    > Die Möglichkeit, Strafen nach Art. 13.4 der FIDE-Regeln zu verhängen, bleibt unberührt.
+    > Die Möglichkeit, Strafen nach Art. 12.9 der FIDE-Regeln zu verhängen, bleibt unberührt.
 
 1.  
     Über die in Ziffer 3.1 genannten Maßnahmen hinaus kann der Nationale Spielleiter der DSJ die folgenden Strafen verhängen:


### PR DESCRIPTION
Die zum 01.07.2014 aktualisierten [FIDE-Regeln](http://srk.schachbund.de/nachrichtenleser-der-srk/deutsche-uebersetzung-der-fide-regeln.html?file=files/dsb/ordnung/FIDERegeln2014-eng.pdf) macht in AB 3.1 folgende Änderung nötig:
- Die Referenz auf FR 13.4 wird durch 12.9 ersetzt.

Die Diskussion und Abstimmung im Arbeitskreis Spielbetrieb steht noch aus.
