### PR TITLE
AB 5.7: Änderung des Meldeprozederes bei Mannschaftsturnieren

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -240,11 +240,11 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Die Mannschaften sind nach Spielstärke aufzustellen. Nach dem Meldeschluss sind keine Nachmeldungen mehr möglich. Die Reihenfolge darf während des Turniers nicht mehr geändert werden. Falsche Brettbesetzung zieht den Partieverlust für die zu tief eingesetzten Spieler nach sich.
 
-    > Zum Meldeschluss können bis zu 15 Spieler in fester Reihenfolge gemeldet werden. Die Mannschaftsmeldung darf von der Aufstellung der Qualifikationsturnier und Landesverbandsmeisterschaften abweichen.
+    > Zum Meldeschluss kann ein Kader von bis zu 15 Spielern gemeldet werden. Er darf von dem der Qualifikationsturniere und Landesverbandsmeisterschaften abweichen.
 
-    > Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche. Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.
+    > Vor Auslosung der ersten Runde wird die feste Reihenfolge der Spieler in der Startrangliste festgelegt. In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind; der Turnierverantwortliche kann Ausnahmen zulassen. Die Startrangliste kann während des Turniers nicht verändert werden.
 
-    > In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind. Die Startrangliste kann während des Turniers nicht verändert werden. Der Turnierverantwortliche kann Ausnahmen zulassen.
+    > Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche.
 
     > Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
 


### PR DESCRIPTION
> **AB zu 5.7 (geltende Fassung)**
> Zum Meldeschluss können bis zu 15 Spieler in fester Reihenfolge gemeldet werden. Die Mannschaftsmeldung darf von der Aufstellung der Qualifikationsturnier und Landesverbandsmeisterschaften abweichen.
> Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche. Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.
> In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind. Die Startrangliste kann während des Turniers nicht verändert werden. Der Turnierverantwortliche kann Ausnahmen zulassen.
> Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
> Bretter können bei Namensnennung freigelassen werden. Das letzte Brett kann ohne Namensnennung freigelassen werden.
> **AB zu 5.7 (neue Fassung)**
> Zum Meldeschluss kann ein Kader von bis zu 15 Spielern gemeldet werden. Er darf von dem der Qualifikationsturniere und Landesverbandsmeisterschaften abweichen.
> Vor Auslosung der ersten Runde wird die feste Reihenfolge der Spieler in der Startrangliste festgelegt. In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind; der Turnierverantwortliche kann Ausnahmen zulassen. Die Startrangliste kann während des Turniers nicht verändert werden.
> Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche.
> Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
> Bretter können bei Namensnennung freigelassen werden. Das letzte Brett kann ohne Namensnennung freigelassen werden.

Die oben genannte Ausführungsbestimmung gilt für all unsere Mannschaftsmeisterschaften – Schulschach-, Länder- und Vereinsmeisterschaften – und bezieht sich auf JSpO 5.7:

> **JSpO 5.7**
> Die Mannschaften sind nach Spielstärke aufzustellen. Nach dem Meldeschluss sind keine Nachmeldungen mehr möglich. Die Reihenfolge darf während des Turniers nicht mehr geändert werden. Falsche Brettbesetzung zieht den Partieverlust für die zu tief eingesetzten Spieler nach sich.

Das Meldeprozedere zu diesen Mannschaftsmeisterschaften hat sich in den zurückliegenden Jahren grundlegend geändert, was am Beispiel der DVM skizziert werden soll. In der Vergangenheit gliederte sich der Meldeprozess in zwei Phasen:
- Anfang November: Postalische Meldung der Mannschaften inklusive der Spielerkader in fester Reihenfolge
- Anreisetag, 26.12.: Meldung der anwesenden Spieler aus dem Kader

Die Einhaltung der 200-Punkte-Grenze wurde auf die Spielerreihenfolge vom November geprüft. Dass sich bis zur Meisterschaft sieben Wochen später die DWZ stark ändern, kam vor Einführung der tagesaktuellen DWZ-Berechnung mittels DEWIS nur selten vor.

In der Zwischenzeit wird die Meldung online vorgenommen. Durch die Einführung tagesaktueller DWZ soll die Prüfung der 200-Punkte-Regel nun zu Turnierbeginn erfolgen. Folgendes Meldeprozedere ist anzustreben (am Beispiel der DVM):
- 15. November: Online-Meldung der Mannschaften inklusive Spielerkader
- Anreisetag, 26.12.: Meldung der anwesenden Spieler aus dem Kader sowie ihre feste Reihenfolge

Dies kommt dem Wunsch insbesondere der Landesverbände nach, die Spielerreihenfolge zur DLM erst während der Anreise endgültig festzulegen. Auch bei den jüngeren DVM-Altersklassen wurde der Wunsch geäußert, die Reihenfolge erst unmittelbar vor Turnierbeginn festzulegen, da sich in den Wochen seit Meldetermin die Spielstärke der Spieler noch stärker ändere.
An dem Meldetermin des Spielerkaders mehrere Wochen vor Turnierbeginn ist festzuhalten, da die Prüfung und der Nachweis der Spielberechtigung nicht erst am Anreisetag erfolgen kann.

Die Prüfung der 200-Punkte-Regelung muss dann jedoch am Anreisetag erfolgen. Die bislang eingeräumte Einspruchsmöglichkeit beim Nationalen Spielleiter entfällt:

> **AB zu 5.7 (geltende Fassung, Auszug)**
> (…) Lehnt er die abgegebene Meldung ab und erfolgte die Mitteilung der Reihenfolge mindestens drei Wochen vor Beginn der Meisterschaft, so kann der Meldende binnen zwei Wochen die Entscheidung vom Nationalen Spielleiter kontrollieren lassen.

Die Einräumung der Ausnahmeregelung in Absatz 3 der geltenden Fassung wird genauer gefasst: Ausnahmen sind einzig insofern möglich, nicht anwesende Spieler in die Startrangliste aufzunehmen. Nicht jedoch darf die Startrangliste während des Turniers geändert werden.
