### PR TITLE
Redaktionelle Änderung: AB 16.1 (per Beschluss JV 2013) aufgenommen

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -535,6 +535,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Spielberechtigt sind abweichend zu 9.1 alle Spieler, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
+    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten.
+
 1.  
     Ziffer 10.2 gilt entsprechend.
 


### PR DESCRIPTION
Die Jugendversammlung 2013 hatte bei der Einführung der DVM U10 die Aufnahme der Ausführungsbestimmung zu JSpO 16.1 beschlossen (vgl. [Antrag](http://www.deutsche-schachjugend.de/fileadmin/dsj_image/wir/Verband/JV_2013/Antrag-AKS-DVM_U10.pdf) und Protokoll):

> Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten.

Diese Ausführungsbestimmung wurde bislang nicht in die Jugendspielordnung übernommen, gleichwohl aber zur DVM 2013 angewandt. Die Ausführungsbestimmung wird als redaktionelle Änderung übernommen.
