### PR TITLE
Änderung AB 5.6: Benennung Mannschaftsführer (Beschluss AKS 01/2014)

### DIFF
--- a/Jugendspielordnung.md
+++ b/Jugendspielordnung.md
@@ -235,7 +235,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Jede Mannschaft benennt dem Turnierleiter einen Mannschaftsführer.
 
-    > Der Mannschaftsführer ist zuständig für die Mannschaftsaufstellung. Er darf während des Turniers seinen Spielern raten, ein Remisangebot anzunehmen oder abzulehnen und ein Remisangebot abzugeben, die Partie aufzugeben oder - auf Anfrage des Spielers - fortzusetzen. Der Mannschaftsführer soll während der Runden erkennbar sein. Der Turnierverantwortliche kann näher zu bestimmende Kennzeichen zur Pflicht machen.
+    > Der Mannschaftsführer oder zuständige Betreuer ist zuständig für die Mannschaftsaufstellung. Der Mannschaftsführer darf während des Turniers seinen Spielern raten, ein Remisangebot anzunehmen oder abzulehnen und ein Remisangebot abzugeben, die Partie aufzugeben oder - auf Anfrage des Spielers - fortzusetzen. Der Mannschaftsführer soll während der Runden erkennbar sein. Der Turnierverantwortliche kann näher zu bestimmende Kennzeichen zur Pflicht machen. Die Ausschreibung kann festlegen, dass nur ein Spieler der Mannschaft die Rolle des Mannschaftsführers übernehmen darf.
 
 1.  
     Die Mannschaften sind nach Spielstärke aufzustellen. Nach dem Meldeschluss sind keine Nachmeldungen mehr möglich. Die Reihenfolge darf während des Turniers nicht mehr geändert werden. Falsche Brettbesetzung zieht den Partieverlust für die zu tief eingesetzten Spieler nach sich.


### PR DESCRIPTION
> **AB zu 5.6 (geltende Fassung)**
> Der Mannschaftsführer ist zuständig für die Mannschaftsaufstellung. Er darf während des Turniers seinen Spielern raten, ein Remisangebot anzunehmen oder abzulehnen und ein Remisangebot abzugeben, die Partie aufzugeben oder – auf Anfrage des Spielers – fortzusetzen. Der Mannschaftsführer soll während der Runden erkennbar sein. Der Turnierverantwortliche kann näher zu bestimmende Kennzeichen zur Pflicht machen.
> **AB zu 5.6 (neue Fassung)**
> Der Mannschaftsführer oder zuständige Betreuer ist zuständig für die Mannschaftsaufstellung. Der Mannschaftsführer darf während des Turniers seinen Spielern raten, ein Remisangebot anzunehmen oder abzulehnen und ein Remisangebot abzugeben, die Partie aufzugeben oder – auf Anfrage des Spielers – fortzusetzen. Der Mannschaftsführer soll während der Runden erkennbar sein. Der Turnierverantwortliche kann näher zu bestimmende Kennzeichen zur Pflicht machen. Die Ausschreibung kann festlegen, dass nur ein Spieler der Mannschaft die Rolle des Mannschaftsführers übernehmen darf.

Bei Meisterschaften, bei denen der nicht spielende Mannschaftsführer deutlich stärker als seine Spieler ist, kommt es immer wieder zu Konfliktsituationen: Durch die Möglichkeit, zur Remisannahme oder -angebot zu raten, hat der Mannschaftsführer einen Einfluss auf einzelne Partien, der über das reine Abschätzen der Wettkampfsituation an allen Brettern hinausgeht. Abgesehen von der Tatsache, dass Partien hierdurch maßgeblich durch den Mannschaftsführer gesteuert werden, bleibt in vielen Fällen auch das Unverständnis der Spieler, die ihre Partie eigentlich gerne ausgespielt hätten.
Der Arbeitskreis Spielbetrieb ist sich bewusst, dass der Rolle des Mannschaftsführers bei Mannschaftskämpfen eine besondere Bedeutung zukommt. Spieler sollen sich bei Mannschaftskämpfen der Bedeutung ihrer eigenen Partie für den Gesamterfolg des Teams bewusst sein; der Mannschaftsführer soll auch weiterhin die Möglichkeit erhalten, im Sinne der Mannschaft zu Remisangeboten und -annahmen zu raten. Verhindert werden soll einzig, dass bei Meisterschaften, bei denen der Spielstärkeunterschied zwischen externem Mannschaftsführer und Spieler zu groß ist, dieser als Hilfsmöglichkeit missbraucht wird. Insofern soll die neue Regel auch vorerst nur bei der DVM U10 und U12 genutzt werden.
Bei der DVM U10 im vergangenen Jahr wurde eine ähnliche Handhabe bereits durchgesetzt und erntete viel Zustimmung.
Um den spielenden Mannschaftsführer zu entlasten, soll auch der offizielle Betreuer der Mannschaft das Recht erhalten, die Mannschaftsaufstellung zu benennen, was auch der bisherigen Praxis entspricht. Ein Einspruchsrecht hat der offizielle Betreuer gemäß der Rechts- und Verfahrensordnung § 5 ebenfalls.
