### PR TITLE
JSpO 16.1: Spielberechtigung DVM U10 durch Vereinsmitgliedschaft

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -535,7 +535,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
 
 1.  
-    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Spielberechtigt sind abweichend zu 9.1 alle Spieler, die in der laufenden Saison für diesen Verein spielberechtigt sind.
+    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendliche, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten.
 

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -535,7 +535,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
 
 1.  
-    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendliche, die in der laufenden Saison für diesen Verein spielberechtigt sind.
+    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten.
 


### PR DESCRIPTION
# Antrag zur Jugendversammlung

> __JSpO 16.1 (geltende Fassung)__
> An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Spielberechtigt sind abweichend zu 9.1 alle Spieler, die in der laufenden Saison für diesen Verein spielberechtigt sind.
> __JSpO 16.1 (neue Fassung)__
> An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.

Die Deutsche Vereinsmeisterschaft U10 genießt eine besondere Rolle in allen DVM-Turnieren: Sie wird als offenes Turnier mit verkürzter Bedenkzeit ausgetragen und trägt bei alljährlich etwa 50 teilnehmenden Mannschaften einen Open-Charakter. Durch das junge Alter der Teilnehmer sind Wohnortwechsel der Eltern auch über Landesgrenzen hinaus noch häufiger. Nach Ziffer 1.4 Satz 2 ist die Teilnahme an der DVM derzeit allerdings nur nach einem Jahr in Deutschland möglich. Wir wollen den Anschluss an den lokalen Schachverein auch dadurch erleichtern, dass die Teilnahme an der offenen DVM U10 für diese Kinder ermöglicht wird.

Durch die Abstellung auf die Vereinsmitgliedschaft sieht der AKS kein Missbrauchsrisiko: Die Wahrscheinlichkeit, dass ein Verein Jugendliche ohne Bezug zum deutschen Schach im Verein meldet, nur um in der DVM U10 vorne mitspielen zu können, ist sehr gering. Dass U10-Mannschaften in dieser Aufstellung im Folgejahr dann auch an der DVM U12 - welche auch weiterhin die strengere Spielberechtigung nach Ziffer 1.4 erfordert - teilnehmen können, wird durch Ziffer 1.4 Satz 2 gewährleistet, da der Jugendliche in diesem Fall dann seinen Lebensmittelpunkt seit einem Jahr in Deutschland haben wird.