### PR TITLE
Gastspielgenehmigung in der DVM U20w und U14w

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -454,9 +454,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Stellt ein Verein mehr als eine Mannschaft, sind die weiteren Mannschaften nachrangig zu berücksichtigen.
 
 1.  
-    In jeder Mannschaft ist abweichend von Ziffer 11.1 eine Spielerin startberechtigt, die in der laufenden Saison einem anderen Verein angehört.
+    In jeder Mannschaft ist abweichend von Ziffer 11.1 eine Spielerin startberechtigt, die in der laufenden Saison einem anderen Verein angehört, sofern dieser dem Gastspiel zustimmt.
 
-    > Die Spielberechtigung nach Ziffer 11.3 muss durch den Verein nachgewiesen werden.
+    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an dieser DVM teilnimmt.
 
 1.  
     Ziffer 10.2 gilt entsprechend.
@@ -501,11 +501,11 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     An der DVM U14w nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U14.
 
 1.  
-    In jeder Mannschaft ist abweichend von Ziffer 9.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, wenn sie im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet wurde.
+    In jeder Mannschaft ist abweichend von Ziffer 9.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, sofern dieser dem Gastspiel zustimmt. Sie darf zudem im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet worden sein.
+
+    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an dieser DVM teilnimmt.
 
     > Eine Spielerin, die in der vergangenen Saison für einen anderen Verein spielberechtigt war und nun zu dem Verein gewechselt ist, für den sie bei der DVM eingesetzt werden soll, ist gleichwohl nur als Gastspielerin startberechtigt.
-
-    > Die Ausführungsbestimmung zu 11.3 gilt entsprechend.
 
 1.  
     Ziffer 10.2 gilt entsprechend.

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -456,7 +456,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     In jeder Mannschaft ist abweichend von Ziffer 11.1 eine Spielerin startberechtigt, die in der laufenden Saison einem anderen Verein angehört, sofern dieser dem Gastspiel zustimmt.
 
-    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an dieser DVM teilnimmt.
+    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an einer Altersklasse dieser DVM teilnimmt, für die die Spielerin spielberechtigt ist.
 
 1.  
     Ziffer 10.2 gilt entsprechend.
@@ -503,7 +503,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     In jeder Mannschaft ist abweichend von Ziffer 9.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, sofern dieser dem Gastspiel zustimmt. Sie darf zudem im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet worden sein.
 
-    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an dieser DVM teilnimmt.
+    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an einer Altersklasse dieser DVM teilnimmt, für die die Spielerin spielberechtigt ist.
 
     > Eine Spielerin, die in der vergangenen Saison für einen anderen Verein spielberechtigt war und nun zu dem Verein gewechselt ist, für den sie bei der DVM eingesetzt werden soll, ist gleichwohl nur als Gastspielerin startberechtigt.
 


### PR DESCRIPTION
# Antrag zur Jugendversammlung

## U20w
> __JSpO 11.3 (geltende Fassung)__
> In jeder Mannschaft ist abweichend von Ziffer 11.1 eine Spielerin startberechtigt, die in der laufenden Saison einem anderen Verein angehört.
> __JSpO 11.3 (neue Fassung)__
> In jeder Mannschaft ist abweichend von Ziffer 11.1 eine Spielerin startberechtigt, die in der laufenden Saison einem anderen Verein angehört, sofern dieser dem Gastspiel zustimmt.
> __AB zu 11.3 (neu einzufügen)__
> Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an dieser DVM teilnimmt.

## U14w
> __JSpO 14.2 (geltende Fassung)__
> In jeder Mannschaft ist abweichend von Ziffer 9.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, wenn sie im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet wurde.
> __JSpO 14.2 (neue Fassung)__
> In jeder Mannschaft ist abweichend von Ziffer 9.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, sofern dieser dem Gastspiel zustimmt. Sie darf zudem im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet worden sein.
> __AB zu 14.2 (1) (neu einzufügen)__
> Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an dieser DVM teilnimmt.

## Begründung
Bereits zur [Jugendversammlung 2012](http://www.deutsche-schachjugend.de/fileadmin/dsj_image/wir/Verband/JV_2012/Antrag-AKS-Gastspieler-DVMw.pdf) startete der AKS einen Vorstoß, die Gastspielgenehmigung in der DVM U20w und U14w in die Spielordnung festzuschreiben. Damals wurde der Antrag auf der Jugendversammlung diskutiert und an den AKS noch einmal zur Überarbeitung zurückgegeben. Dieser hat die Kritikpunkte von 2012 eingearbeitet und stellt nun diese überarbeitete Version zur Abstimmung.

An den DVM U20w und U14w darf je Mannschaft eine Gastspielerin teilnehmen. Davon profitieren sowohl Vereine, die andernfalls gar keine Mädchenmannschaft zusammenbekämen, als auch Spielerinnen, die in ihrem Verein nicht genügend Mädchen für eine Mannschaft haben und so doch an der Deutschen Meisterschaft teilnehmen können. Die bislang von den abgebenenden Vereinen geforderte Gastspielgenehmigung war bislang jedoch nicht Teil der Jugendspielordnung, sodass diese nun dem gängigen Verfahren angepasst wird. Die Änderung zielt darauf ab, dass jeder Verein, der eine Gastspielerin einsetzen möchte, vom Heimatverein der Spielerin die schriflichte Genehmigung hierfür einholt. Hiermit soll das berechtigte Interesse des Heimatvereins geschützt werden, die Spielerin selbst in einer DVM-Mannschaft, gleich welcher Altersklasse, einzusetzen. Dieses schützenswerte Interesse liegt insbesondere dann nicht vor, wenn der Heimatverein selbst an keiner DVM teilnimmt. Die Gastspielgenehmigung gilt in diesem Falle als erteilt.

Das im [Antrag von 2012](http://www.deutsche-schachjugend.de/fileadmin/dsj_image/wir/Verband/JV_2012/Antrag-AKS-Gastspieler-DVMw.pdf) von der Jugendversammlung diskutierte Vetorecht des Nationalen Spielleiters findet in der aktualisierten Fassung keine Berücksichtigung mehr.