### PR TITLE
JV 2015: Antrag der SJ NDS und BRE zur Mannschaftsführergestellung

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -237,7 +237,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Jede Mannschaft benennt dem Turnierleiter einen Mannschaftsführer.
 
-    > Der Mannschaftsführer oder zuständige Betreuer ist zuständig für die Mannschaftsaufstellung. Der Mannschaftsführer darf während des Turniers seinen Spielern raten, ein Remisangebot anzunehmen oder abzulehnen und ein Remisangebot abzugeben, die Partie aufzugeben oder - auf Anfrage des Spielers - fortzusetzen. Der Mannschaftsführer soll während der Runden erkennbar sein. Der Turnierverantwortliche kann näher zu bestimmende Kennzeichen zur Pflicht machen. Die Ausschreibung kann festlegen, dass nur ein Spieler der Mannschaft die Rolle des Mannschaftsführers übernehmen darf.
+    > Der Mannschaftsführer oder zuständige Betreuer ist zuständig für die Mannschaftsaufstellung. Der Mannschaftsführer darf während des Turniers seinen Spielern raten, ein Remisangebot anzunehmen oder abzulehnen und ein Remisangebot abzugeben, die Partie aufzugeben oder - auf Anfrage des Spielers - fortzusetzen. Der Mannschaftsführer soll während der Runden erkennbar sein. Der Turnierverantwortliche kann näher zu bestimmende Kennzeichen zur Pflicht machen. Mannschaftsführer kann sowohl ein Spieler als auch ein Mitreisender sein.
 
 1.  
     Die Mannschaften sind nach Spielstärke aufzustellen. Nach dem Meldeschluss sind keine Nachmeldungen mehr möglich. Die Reihenfolge darf während des Turniers nicht mehr geändert werden. Falsche Brettbesetzung zieht den Partieverlust für die zu tief eingesetzten Spieler nach sich.


### PR DESCRIPTION
> # Antrag der Schachjugenden Niedersachsen und Bremen
>
> Der Arbeitskreis Spielbetrieb wird beauftragt folgende Ausführungsbestimmung anzupassen:
> > __Aktueller Wortlaut der Ausführungsbestimmungen zu 5.6__
Die Ausschreibung kann festlegen, dass nur ein Spieler der Mannschaft die Rolle des
Mannschaftsführers übernehmen darf.
__Neue Formulierung zu 5.6__
Mannschaftsführer kann sowohl ein Spieler als auch ein Mitreisender sein.
>
> ## Begründung
> Die Sonderregelung, dass bei der DVM U10 nur ein Spieler Mannschaftsführer sein kann, hat auch negative Seiten. Der Spieler könnte z.B. überfordert werden. Die Kinder sollen es kennen lernen, dass man Schach auch als Mannschaftssport austragen kann. 
gez. Ulrike Schlüter Bremer Schachjugend
gez. Jan Salzmann Niedersächsische Schachjugend