### PR TITLE
JV 2015: Antrag der SJ BER zur Berechnung der DEM-Kontingente

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -284,7 +284,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     Es können jeweils bis zu zehn weitere Freiplätze vergeben werden. Der AKS kann das Freiplatzkontingent bei außergewöhnlichen Umständen um jeweils bis zu vier weitere Freiplätze erhöhen.
 
-    > Berechnung der Teilnehmerzahlen der Landesverbände für die DEM U14: Es wird eine Rangliste nach Jahreswertungspunkten analog zu den Regelungen zu 7.2 erstellt. Entsprechend der Rangliste werden Plätze vergeben; bei Punktgleichheit entscheidet das aktuellste Jahr.
+    > Berechnung der Teilnehmerzahlen der Landesverbände für die DEM U14: Es wird eine Rangliste nach Jahreswertungspunkten analog zu den Regelungen für die U12 zu 7.2 erstellt. Entsprechend der Rangliste werden Plätze vergeben; bei Punktgleichheit entscheidet das aktuellste Jahr.
     >
     > 1.-6. Platz = 3 Teilnehmer, 7.-12. Platz = 2 Teilnehmer, 13.-17. Platz = 1 Teilnehmer.
     >
@@ -310,17 +310,25 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Die Teilnehmerzahlen der Landesverbände werden auf Grundlage der bei den vergangenen zwei DEM der jeweiligen und, soweit vorhanden, der nächstjüngeren Altersklasse erzielten Punkte zugeteilt, wobei zwischen jüngerem und älterem Jahrgang innerhalb der Altersklasse unterschieden wird. Für vordere Platzierungen erhalten die Landesverbände Bonuspunkte. Die Berechnungsweise regeln die Ausführungsbestimmungen. Es können weitere Freiplätze vergeben werden.
 
-    > Die Zahl der Startplätze pro Landesverband steht - mit Ausnahme der Kaderspieler und des Ausrichterfreiplatzes - schon unmittelbar nach dem alten Turnier fest, es muss nicht bis zum ZPS-Termin (Erscheinen der aktuellen Mitgliederzahlen am 15. Januar des Folgejahres) gewartet werden. Es wird eine Rangliste (nach JWP) der Verbände, basierend auf den Resultaten der letzten drei Deutschen Einzelmeisterschaften U12, erstellt und dann eine eindeutige Zuordnung von Plätzen vorgenommen.
+    > Die Zahl der Startplätze pro Landesverband steht - mit Ausnahme der Kaderspieler und des Ausrichterfreiplatzes - schon unmittelbar nach dem alten Turnier fest, es muss nicht bis zum ZPS-Termin (Erscheinen der aktuellen Mitgliederzahlen am 15. Januar des Folgejahres) gewartet werden. Es wird eine Rangliste (nach JWP) der Verbände, basierend auf den Resultaten der letzten zwei Deutschen Einzelmeisterschaften, erstellt und dann eine eindeutige Zuordnung von Plätzen vorgenommen.
     >
-    > Bei der Berechnung soll die von den Spielern gezeigte Leistung bei den zurückliegenden Meisterschaften als Hauptkriterium dienen. Dazu werden die Ergebnisse der drei zurückliegenden Jahre herangezogen. Da jedes Turnier nach gleichem System absolviert wird (11 Runden Schweizer System), sind die Ergebnisse der vergangenen Jahre vergleichbar. Der Zeitraum von drei Jahren verlangt von den Verbänden eine dreijährige kontinuierliche Arbeit im Jugendbereich, fängt aber zugleich ein einmaliges schwächeres Ergebnis auf. Ermittelt werden die Gesamtpunktzahlen der Spieler jedes Landesverbands. Holt also ein Spieler 6.5 Punkte in den 11 Partien, werden dem Landesverband entsprechend 6.5 Zähler addiert. Die Ausrichterfreiplätze werden dabei nicht berücksichtigt.
+    > Bei der Berechnung soll die von den für die aktuelle DEM in der Altersklasse spielberechtigten Spielern gezeigte Leistung der zurückliegenden Meisterschaft als Hauptkriterium dienen. Um kontinuierliche Arbeit im Jugendbereich in den Landesverbänden zu belohnen, werden zusätzlich Leistungen der Spieler derselben Altersklasse der beiden zurückliegenden Meisterschaften herangezogen.
     >
-    > Aus der Summe aller Spieler eines Landesverbands wird der Durchschnitt berechnet. Zusätzlich zu diesem Durchschnittswert erhält der Verband Bonuspunkte, wenn eine Spielerin oder ein Spieler unter den ersten zehn der Abschlusstabelle platziert ist. Es gibt dafür 1.0 bis 0.1 Punkte. Mädchen, die unter den ersten zehn des Gesamtturniers platziert sind, punkten dabei auch für die Jungen des Verbandes. Bei den Mädchen werden die ersten fünf Platzierten zusätzlich mit Bonuspunkten (0.5 bis 0.1) für die Mädchenwertung versehen.
+    > Dazu werden in der jeweiligen Altersklasse die Spieler jedes Landesverbands in älteren und jüngeren Jahrgang (bzw. jüngere Jahrgänge) unterteilt. Ermittelt werden die Gesamtpunktzahlen der Spieler jedes Landesverbandes im jeweiligen Jahrgang. Holt also ein Spieler jüngeren Jahrgangs (respektive älteren Jahrgangs) 6.5 Punkte in den 11 Partien, werden dem Landesverband entsprechend 6.5 Zähler beim jüngeren Jahrgang (resp. älteren Jahrgang) addiert. Die Ausrichterfreiplätze werden dabei nicht berücksichtigt.
+    >
+    > Aus der Summe aller Spieler des jeweiligen Jahrgangs eines Landesverbands wird der Durchschnitt berechnet. Zusätzlich zu diesem Durchschnittswert erhält der Verband Bonuspunkte im entsprechenden Jahrgang, wenn eine Spielerin oder ein Spieler des Jahrgangs unter den ersten zehn der Abschlusstabelle platziert ist. Es gibt dafür 1.0 bis 0.1 Punkte. Mädchen, die unter den ersten zehn des Gesamtturniers platziert sind, punkten dabei auch für die Jungen des Verbandes. Bei den Mädchen werden die ersten fünf Platzierten zusätzlich mit Bonuspunkten (0.5 bis 0.1) für die Mädchenwertung versehen.
     >
     > Meldet ein Landesverband für einen Jungen-Startplatz ein Mädchen, so wird dieses auf Antrag des Landesverbandes für die Jungenwertung herangezogen. Der Antrag muss vor Beginn der ersten Runde der Meisterschaft beim Nationalen Spielleiter eingehen.
     >
-    > Die so erreichten Jahreswertungspunkte werden zu einem Gesamtergebnis addiert. Dabei erfahren die beiden letzten Jahre eine doppelte, das drittletzte Jahr eine einfache Gewichtung. Beispiel: Baden holte 1994 4.7 JWP, 1995 3.6 JWP, 1996 4.0 JWP. Insgesamt ergeben sich für die Rangliste der Verbände (4.7 x 1) + (3.6 x 2) + (4.0 x 2) = 19.9 JWP für Baden.
+    > Die so erreichten Jahreswertungspunkte (JWP) werden in der jeweiligen Altersklasse zu einem Gesamtergebnis addiert.
     >
-    > Entsprechend der Rangliste werden Plätze vergeben; bei Punktgleichheit entscheidet das aktuellste Jahr.
+    > In der U12 gehen aus dem Vorjahr die JWP des jüngeren Jahrgangs der U12 zu 50%, die JWP des älteren Jahrgangs der U10 zu 25% und die JWP des älteren Jahrgangs der U12 zu 10%, sowie die JWP der gesamten U12 des vorletzten Jahres zu 15% ein.
+    >
+    > In der U10 gehen aus dem Vorjahr die JWP des jüngeren Jahrgangs der U10 zu 60% und die JWP des älteren Jahrgangs der U10 zu 15%, sowie die JWP der gesamten U10 des vorletzten Jahres zu 25% ein.
+    >
+    > Beispiel: Berlin holte auf der DEM 2014 im jüngeren Jahrgang U12 5.250 JWP, im älteren Jahrgang U10 6.333 JWP, im älteren Jahrgang U12 6.150 JWP und auf der DEM 2013 in der U12 6.250 JWP. Insgesamt ergeben dich für die Rangliste der Verbände für Berlin 0.5 * 5.250 + 0.25 * 6.333 + 0.1 * 6.150 + 0.15 * 6.250 = 5.761 Gesamtpunkte.
+    >
+    > Entsprechend der Rangliste werden Plätze vergeben; bei Punktgleichheit entscheiden die JWP derselben Altersklasse des Vorjahres.
     >
     > Jungen: 1. Platz = 5 Teilnehmer, 2.-5. Platz = 4 Teilnehmer, 6.-10. Platz = 3 Teilnehmer, 11.-17. Platz = 2 Teilnehmer. Mädchen: 1. Platz = 3 Teilnehmerinnen, 2.-8. Platz = 2 Teilnehmerinnen, 9.-17. Platz = 1 Teilnehmerin.
     >

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -278,7 +278,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     Für die DEM U18, U18w, U16, U16w und U14w: Jeder Landesverband entsendet pro Altersklasse einen Teilnehmer. Je ein weiterer Platz wird an die beiden Landesverbände mit den meisten gemeldeten Mitgliedern in der jeweiligen Altersklasse vergeben.
 
-    Für die DEM U14: Die Landesverbände entsenden insgesamt 35 Teilnehmer. Die Teilnehmerzahlen der Landesverbände werden auf der Grundlage der bei den vergangenen drei DEM der jeweiligen Altersklasse erzielten Punkte zugeteilt. Für vordere Platzierungen erhalten die Landesverbände Bonuspunkte. Die Berechnungsweise regeln die Ausführungsbestimmungen.
+    Für die DEM U14: Die Landesverbände entsenden insgesamt 35 Teilnehmer. Die Teilnehmerzahlen der Landesverbände werden auf Grundlage der bei den vergangenen zwei DEM der jeweiligen und der nächstjüngeren Altersklasse erzielten Punkte zugeteilt, wobei zwischen jüngerem und älterem Jahrgang innerhalb der Altersklasse unterschieden wird. Für vordere Platzierungen erhalten die Landesverbände Bonuspunkte. Die Berechnungsweise regeln die Ausführungsbestimmungen.
 
     Der Ausrichter erhält jeweils einen Freiplatz.
 
@@ -308,7 +308,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 75 Minuten für 40 Züge, danach zusätzliche 15 Minuten für die restlichen Züge, bei zusätzlichen 30 Sekunden pro Zug von Beginn an.
 
 1.  
-    Die Teilnehmerzahlen der Landesverbände werden auf der Grundlage der bei den vergangenen drei DEM der jeweiligen Altersklasse erzielten Punkte zugeteilt. Für vordere Platzierungen erhalten die Landesverbände Bonuspunkte. Die Berechnungsweise regeln die Ausführungsbestimmungen. Es können weitere Freiplätze vergeben werden.
+    Die Teilnehmerzahlen der Landesverbände werden auf Grundlage der bei den vergangenen zwei DEM der jeweiligen und, soweit vorhanden, der nächstjüngeren Altersklasse erzielten Punkte zugeteilt, wobei zwischen jüngerem und älterem Jahrgang innerhalb der Altersklasse unterschieden wird. Für vordere Platzierungen erhalten die Landesverbände Bonuspunkte. Die Berechnungsweise regeln die Ausführungsbestimmungen. Es können weitere Freiplätze vergeben werden.
 
     > Die Zahl der Startplätze pro Landesverband steht - mit Ausnahme der Kaderspieler und des Ausrichterfreiplatzes - schon unmittelbar nach dem alten Turnier fest, es muss nicht bis zum ZPS-Termin (Erscheinen der aktuellen Mitgliederzahlen am 15. Januar des Folgejahres) gewartet werden. Es wird eine Rangliste (nach JWP) der Verbände, basierend auf den Resultaten der letzten drei Deutschen Einzelmeisterschaften U12, erstellt und dann eine eindeutige Zuordnung von Plätzen vorgenommen.
     >


### PR DESCRIPTION
# [Antrag 1](790217a)
> Der Jugendausschuss des Berliner Schachverbands e.V. beantragt die Änderung der
Jugendspielordnung der DSJ wie folgt:
> *(siehe Commit 790217a)*
> ## Begründung
> Die Berechnung der Teilnehmerzahlen der Landesverbände für die DEM sollte bei den großen Startfeldern der Altersklassen U14, U12, U12w, U10 und U10w hauptsächlich auf dem Erfolg derjenigen Spieler beruhen, die für die entsprechende Altersklasse auch spielberechtigt sind. Beispielsweise sollte für die AK U12 vorwiegend der jüngere Jahrgang der AK U12 und der ältere Jahrgang der AK U10 der DEM des vorangegangenen Jahres in die Berechnung eingehen.
> Nach derzeitigen Bestimmungen sind für die Berechnung der Teilnehmerzahlen in einer Altersklasse die Ergebnisse der letzten drei Jahre derselben Altersklasse maßgeblich. Dies führt dazu, dass nur ein kleiner Teil derjenigen, die die Startplätze erspielt haben, diese Plätze überhaupt wahrnehmen können.
> __Beispiel:__
> Für die Berechnung der Plätze der AK U12 für die DEM 2015 werden die Jahreswertungspunkte der AK U12 der DEMs der Jahre 2012, 2013 und 2014 herangezogen, aber nur der jüngere Jahrgang der AK U12 der DEM 2014 darf überhaupt noch an der DEM 2015 AK U12 teilnehmen. Die anderen für die Kontingentermittlung berücksichtigten Spieler sind „nur noch“ für die AK U14; der ältere Jahrgang der AK U12 aus dem Jahr 2012 sogar „nur noch“ für die AK U16 spielberechtigt.
> Dies führt insbesondere zu folgendem Effekt: Hat ein Landesverband in einem Jahrgang einige wenige sehr gute Spieler, vielleicht auch noch Freiplatzempfänger der 1. oder 2. Runde, die ein sehr gutes Resultat bei der DEM erspielen, dann garantiert die derzeitige Berechnung diesem Landesverband in der entsprechenden Altersklasse eine dauerhaft höhere Teilnehmerzahl, obwohl diese guten Spieler für die AK nicht mehr spielberechtigt sind und der Landesverband diesen „Mehrplatz“ in der AK evtl. nicht für eine DEM adäquat besetzen kann.
> Der gegenteilige Effekt, dass ein Landesverband viele gute Teilnehmer in einer Altersklasse hat, diese aber nicht zur DEM schicken kann, da vorangegangene Jahrgänge bei den DEMs nicht so stark abschnitten, tritt auch auf.
> Mit unserem Antrag, die Jugendspielordnung (und die entsprechenden Ausführungsbestimmungen, siehe 2. Antrag) zu ändern, wird sichergestellt, dass ein Großteil der Gesamtpunkte der Landesverbände für die einzelnen AKs durch diejenigen Kinder / Jugendlichen erspielt wird, die im entsprechenden Jahr auch noch für diese AK spielberechtigt sind. Um den Gedanken der DSJ, die kontinuierliche Jugendarbeit der Landesverbände, zu unterstützen, erhalten gut aufspielende Landesverbände einen Bonus, in dem auch der herauswachsende, ältere Jahrgang der AK und der gesamte Jahrgang der AK zwei Jahre zuvor mit in die Berechnung eingehen.

# [Antrag 2](f47a9c7)
> Der Jugendausschuss des Berliner Schachverbands e.V. beantragt die Änderung der zu den Änderungen aus Antrag Nr. 1 der Jugendspielordnung zugehörigen Ausführungsbestimmungen der Jugendspielordnung DSJ wie folgt:
> *(siehe Commit f47a9c7)*
> ## Begründung
> Die Berechnung der Teilnehmerzahlen der Landesverbände für die DEM sollte bei den großen Startfeldern der Altersklassen U14, U12, U12w, U10 und U10w hauptsächlich auf dem Erfolg derjenigen Spieler beruhen, die für die entsprechende Altersklasse auch spielberechtigt sind. Beispielsweise sollte für die AK U12 vorwiegend der jüngere Jahrgang der AK U12 und der ältere Jahrgang der AK U10 der DEM des vorangegangenen Jahres in die Berechnung eingehen.
> Nach derzeitigen Bestimmungen sind für die Berechnung der Teilnehmerzahlen in einer Altersklasse die Ergebnisse der letzten drei Jahre derselben Altersklasse maßgeblich. Dies führt dazu, dass nur ein kleiner Teil derjenigen, die die Startplätze erspielt haben, diese Plätze überhaupt wahrnehmen können.
> __Beispiel:__
> Für die Berechnung der Plätze der AK U12 für die DEM 2015 werden die Jahreswertungspunkte der AK U12 der DEMs der Jahre 2012, 2013 und 2014 herangezogen, aber nur der jüngere Jahrgang der AK U12 der DEM 2014 darf überhaupt noch an der DEM 2015 AK U12 teilnehmen. Die anderen für die Kontingentermittlung berücksichtigten Spieler sind „nur noch“ für die AK U14; der ältere Jahrgang der AK U12 aus dem Jahr 2012 sogar „nur noch“ für die AK U16 spielberechtigt.
> Dies führt insbesondere zu folgendem Effekt: Hat ein Landesverband in einem Jahrgang einige wenige sehr gute Spieler, vielleicht auch noch Freiplatzempfänger der 1. oder 2. Runde, die ein sehr gutes Resultat bei der DEM erspielen, dann garantiert die derzeitige Berechnung diesem Landesverband in der entsprechenden Altersklasse eine dauerhaft höhere Teilnehmerzahl, obwohl diese guten Spieler für die AK nicht mehr spielberechtigt sind und der Landesverband diesen „Mehrplatz“ in der AK evtl. nicht für eine DEM adäquat besetzen kann.
> Der gegenteilige Effekt, dass ein Landesverband viele gute Teilnehmer in einer Altersklasse hat, diese aber nicht zur DEM schicken kann, da vorangegangene Jahrgänge bei den DEMs nicht so stark abschnitten, tritt auch auf.
> Mit unserem Antrag, die Ausführungsbestimmungen (nachdem die Jugendspielordnung geändert wurde) zu ändern, wird sichergestellt, dass ein Großteil der Gesamtpunkte der Landesverbände für die einzelnen AKs durch diejenigen Kinder / Jugendlichen erspielt wird, die im entsprechenden Jahr auch noch für diese AK spielberechtigt sind. Um den Gedanken der DSJ, die kontinuierliche Jugendarbeit der Landesverbände, zu unterstützen, erhalten gut aufspielende Landesverbände einen Bonus, in dem auch der herauswachsende, ältere Jahrgang der AK und der gesamte Jahrgang der AK zwei Jahre zuvor mit in die Berechnung eingehen.