### PR TITLE
DVM: Ausrichterfreiplatz kann durch anderen Verein der Regionalgruppe besetzt werden

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -379,7 +379,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
 
-    > Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt.
+    > Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt. Nimmt der Ausrichter seinen Freiplatz nicht wahr, kann der Platz durch eine andere Mannschaft seiner Regionalgruppe besetzt werden.
 
     > Die Hälfte der nach Abzug der Ausrichterfreiplätze zu vergebenden Plätze einer Meisterschaft wird nach der Anzahl der gemeldeten Jugendlichen auf die Regionalgruppen verteilt (Quantität), die andere Hälfte wird nach den Ergebnissen der letzten drei Jahre auf die Regionalgruppen verteilt (Qualität). Das Auf- und Abrunden der Teilnehmerzahlen erfolgt nach der Addition der beiden Kriterien.
     >


### PR DESCRIPTION
> **AB zu 8.4 (Satz 1, geltende Fassung)**
> Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt.
> **AB zu 8.4 (Satz 1 und 2, neue Fassung)**
> Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt. Nimmt der Ausrichter seinen Freiplatz nicht wahr, kann der Platz durch eine andere Mannschaft seiner Regionalgruppe besetzt werden.

*Commit f14b22b*

In der Vergangenheit kam es immer wieder vor, dass Ausrichter einer DVM selbst nicht an dem Turnier teilnahmen. Gründe hierfür waren:
* Mehrfachausrichtung von Altersklassen, sodass einzelne Turniere vorwiegend zwecks Synergieeffekten und Objektauslastung ausgerichtet wurden;
* Gleichzeitige Qualifikation in einer anderen Altersklasse;
* Gemeinsame Ausrichtung durch mehrere Vereine;
* Ausrichtung durch einen Landesverband.

Bei der DVM 2015 nahmen in den fünf geschlossenen Turnieren U12, U14, U14w, U16 und U20 nur zwei Ausrichter selbst mit einer Mannschaft teil. Wenngleich diese geringe Quote in der Zukunft wieder angehoben werden soll, soll der positive Effekt einer Ausrichtung zumindest in der Form erhalten werden, dass ein lokaler Verein die Möglichkeit zur Teilnahme erhält. Verzichtet der Ausrichter also selbst auf eine Teilnahme, soll dieser Platz gleichwohl von einem anderen Verein der Region wahrgenommen werden können. Die Auswahl eines geeigneten Vereins erfolgt in Absprache des Ausrichters und DVM-Referenten resp. Nationalen Spielleiters oder AKS. So wie die Nutzung des regulären Ausrichterfreiplatzes nicht an formale Kriterien wie Spielstärke gebunden ist, trifft dies auch für den Nachrücker aus der Regionalgruppe zu.

In den zurückliegenden Jahren wurde diese Vorgehensweise bereits angewandt. Sie soll nun auch formal beschlossen werden, da der bisherige Regelungstext bislang einzig auf die ausschließliche Nutzung des Freiplatzes durch den Ausrichter abzielte. Durch die Neuerung soll auch die Ausrichtung durch Landesverbände oder andere Organisationen gestärkt werden.