### PR TITLE
Anhang G4 in DVM U10 nicht anwenden

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -514,7 +514,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
-    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten.
+    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang G4 der FIDE-Regeln findet keine Anwendung.
 
 1.  
     Ziffer 9.2 gilt entsprechend.


### PR DESCRIPTION
Im Zuge der letzten Änderungen der FIDE-Regeln wurde der ehemalige Artikel 10.2 (Remisantrag in der Endspurtphase) in den Anhang G verschoben. Die Endspurtphase kommt nur in Schnellschachpartien mit fester Grundbedenkzeit zu tragen, also in der DVM U10, die mit einer Bedenkzeit von einer Stunde ausgetragen wird.

Anhang G4 schafft die neue Möglichkeit, dass der Spieler statt den Schiedsrichter um eine Remisentscheidung zu ersuchen die Umstellung auf eine Inkrementbedenkzeit einfordern kann. Die FIDE-Regeln räumen im folgenden Anhang G5 ein, dass diese Regelung im Vorfeld außer Kraft gesetzt werden kann.

Der AKS hat auf seiner Sitzung am 8. Januar 2016 in Düsseldorf entschieden, von dieser Möglichkeit Gebrauch zu machen und die Anwendung von G4 bei der DVM U10 zu unterbinden. Es scheint in dieser jungen Altersklasse nicht praxistauglich, während der Partie die Bedenkzeit zu wechseln.