### PR TITLE
JV 2016: Antrag der SJ Württemberg zur Einführung einer DEM U8

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -24,6 +24,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     *   Deutsche Einzelmeisterschaften für weibliche Jugendliche unter 12 Jahren (DEM U12w),
     *   Deutsche Einzelmeisterschaften für Jugendliche unter 10 Jahren (DEM U10),
     *   Deutsche Einzelmeisterschaften für weibliche Jugendliche unter 10 Jahren (DEM U10w),
+    *   Deutsche Einzelmeisterschaften für Jugendliche unter 8 Jahren (DEM U8),
     *   Deutsche Meisterschaften für Länder-Jugendmannschaften (DLM),
     *   Deutsche Meisterschaft für Vereins-Jugendmannschaften (DVM U20),
     *   Deutsche Meisterschaft für Vereinsmannschaften der weiblichen Jugend (DVM U20w),


### PR DESCRIPTION
> ## Begründung
> Die Jugendlichen starten mittlerweile in immer jüngerem Alter mit dem Leistungssport. Dem soll mit der Einführung einer DEM U8 Rechnung getragen werden. Auch wird der Startplatz bei der U8-WM und U8-EM bisher nicht sportlich ausgekämpft, sondern vom Bundesnachwuchstrainer festgelegt.
> Die detaillierten Bestimmungen bzw. Ausführungsbestimmungen (§6 Startplätze usw.) soll der AK Spielbetrieb ausarbeiten und der Jugendversammlung 2017 zur endgültigen Abstimmung vorlegen.