### PR TITLE
AB 5.7: Abweichende Kadergröße bei Mannschaftsturnieren durch Festlegung in der Ausschreibung

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -244,7 +244,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Die Mannschaften sind nach Spielstärke aufzustellen. Nach dem Meldeschluss sind keine Nachmeldungen mehr möglich. Die Reihenfolge darf während des Turniers nicht mehr geändert werden. Falsche Brettbesetzung zieht den Partieverlust für die zu tief eingesetzten Spieler nach sich.
 
-    > Zum Meldeschluss kann ein Kader von bis zu 15 Spielern gemeldet werden. Er darf von dem der Qualifikationsturniere und Landesverbandsmeisterschaften abweichen.
+    > Zum Meldeschluss kann ein Kader von bis zu 15 Spielern gemeldet werden. Er darf von dem der Qualifikationsturniere und Landesverbandsmeisterschaften abweichen. Die Ausschreibung kann eine abweichende Kadergröße festlegen.
 
     > Vor Auslosung der ersten Runde wird die feste Reihenfolge der Spieler in der Startrangliste festgelegt. In die Startrangliste werden nur Spieler aufgenommen, die vor Ort anwesend sind; der Turnierverantwortliche kann Ausnahmen zulassen. Die Startrangliste kann während des Turniers nicht verändert werden.
 


### PR DESCRIPTION
Im oben genannten Auszug wird auf das Meldeprozedere im Vorfeld von Mannschaftsmeisterschaften eingegangen. Die genannte Ausführungsbestimmung gilt für all unsere Mannschaftsmeisterschaften – Schulschach-, Länder- und Vereinsmeisterschaften. Diese weisen unterschiedliche Mannschaftsgrößen auf: Bei den DVM reisen Mannschaften mit bis zu fünf Jugendlichen (davon ein/e Ersatzspieler/in), bei der DLM mit bis zu zehn Jugendlichen (davon zwei Ersatzspieler/innen). Diese sehr unterschiedliche Mannschaftsgröße spiegelt sich derzeit nicht in der Größe der im Vorfeld zu meldenden Mannschaftskader wider.
Die feste Kadergröße von 15 ließe bei der Meldung zur DLM nur fünf Reservemeldungen zu. Der frühe Meldetermin von i.d.R. vier Wochen im Voraus erlaubt jedoch keine solch verbindliche Planungssicherheit. So wurden bereits in den Ausschreibungen zur DLM 2015 und 2016 Abweichungen in der Kadergröße festgelegt.
