### PR TITLE
Vereins- und Verbandspaarungen bei Mannschaftsturnieren

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -260,7 +260,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Soweit nach der Spielordnung die Teilnahme mehrerer Mannschaften eines Landesverbands bzw. eines Vereins zugelassen ist, können in den Ausführungsbestimmungen insoweit Abweichungen von und Ergänzungen zu der Spielordnung erlassen werden.
 
-    > Abweichend zu AB zu 2.1 (1) hat der Turnierverantwortliche die Auslosung dahingehend zu beeinflussen, dass die zwei in der Startrangliste am höchsten geführten Mannschaften des gleichen Landesverbands (bei den Ländermeisterschaften) bzw. des gleichen Vereins (bei den Vereinsmeisterschaften) in möglichst früher Runde aufeinander treffen.
+    > Reisen 20 oder weniger Mannschaften an, hat der Turnierverantwortliche abweichend zu AB zu 2.1 (1) die Auslosung dahingehend zu beeinflussen, dass die zwei in der Startrangliste am höchsten geführten Mannschaften des gleichen Landesverbands (bei den Ländermeisterschaften) bzw. des gleichen Vereins (bei den Vereinsmeisterschaften) in möglichst früher Runde aufeinander treffen.
 
     > Die Mannschaftskader samt Ersatzspielern sind getrennt zu bilden.
 


### PR DESCRIPTION
> **AB zu 5.9, Absatz 1 (geltende Fassung)**
> Abweichend zu AB zu 2.1 (1) hat der Turnierverantwortliche die Auslosung dahingehend zu beeinflussen, dass die zwei in der Startrangliste am höchsten geführten Mannschaften des gleichen Landesverbands (bei den Ländermeisterschaften) bzw. des gleichen Vereins (bei den Vereinsmeisterschaften) in möglichst früher Runde aufeinander treffen.
> **AB zu 5.9, Absatz 1 (neue Fassung)**
> Reisen 20 oder weniger Mannschaften an, hat der Turnierverantwortliche abweichend zu AB zu 2.1 (1) die Auslosung dahingehend zu beeinflussen, dass die zwei in der Startrangliste am höchsten geführten Mannschaften des gleichen Landesverbands (bei den Ländermeisterschaften) bzw. des gleichen Vereins (bei den Vereinsmeisterschaften) in möglichst früher Runde aufeinander treffen.

*Commit 331dd6bd99fd4739b9df6a4f8e78e3b86713081c*

Die Erzwingung von vereinsinternen Duellen stellt regelmäßig ein Ärgernis für Vereine der Offenen DVM U10 dar, die mit mehreren Mannschaften antreten. Die bestehende Regelung soll vermeiden, dass es in einer der letzten Runden zum internen Duell kommt und so direkt Einfluss auf den Turnierausgang genommen werden kann. Insbesondere bei der DVM U10, die zuletzt mit 60 Teams ausgespielt wurde, ist das Risiko des Aufeinandertreffens jedoch gering und jedenfalls nicht beim Kampf um vordere Plätze wahrscheinlich. Falls es doch in einer der letzten Runden zum direkten Duell kommen sollte und es um Platzierungen geht, sind andere Maßnahmen geeigneter, Betrugsversuche zu verhindern.

Verbands- und Vereinsduelle können daneben auch bei der Offenen DVM U20w und DLM auftreten. In der U20w war das Teilnehmerfeld zuletzt so klein, dass ein Aufeinandertreffen in irgendeiner Runde äußerst wahrscheinlich ist, sodass dieses interne Duell auch weiterhin in der ersten Runde auszutragen ist. Für die DLM (und auch DVM U10) ist für den AKS langfristig sogar das andere Extrem denkbar und könnte so gänzlich die unattraktiven Verbands- bzw. Vereinsduelle unterbunden werden.

Die aufgeworfene Änderung zielt bislang einzig auf die Lockerung der Anforderungen an die DVM U10 ab, sodass vereinsinterne Duelle zwar auftreten können, jedoch nicht in der 1. Runde forciert werden. In den nicht-offenen DVM U12, U14, U14w, U16 und U20 dürfen gemäß JSpO  8.5 je Verein nur eine Mannschaft antreten, sodass die Regelung hier im Allgemeinen ohnehin keine Anwendung findet. Nur der Ausrichter darf im Falle eines kurzfristigen Ausfalls und zum Gerademachen des Feldes bei diesen DVM eine zweite Mannschaft stellen. Auch dann macht eine interne Paarung in Runde 1 weiterhin Sinn.

Sollten an einer DVM U20w oder DLM mehr als 20 Teams teilnehmen, wird auch hier vom Zwang der Vereins- bzw. Verbandsduelle in der 1. Runde abgewichen.