### PR TITLE
Streichung AB zu 14.1 (Abweichung von Standardbedenkzeit in der DVM U12)

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -498,8 +498,6 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U12 nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U12.
 
-    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 75 Minuten für 40 Züge, danach zusätzliche 15 Minuten für die restlichen Züge, bei zusätzlichen 30 Sekunden pro Zug von Beginn an.
-
 1.  
     Ziffer 9.2 gilt entsprechend.
 


### PR DESCRIPTION
## Antrag zur Jugendversammlung 2017

> **AB zu 14.1 (geltende Fassung, zu streichen)**
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 75 Minuten für 40 Züge, danach zusätzliche 15 Minuten für die restlichen Züge, bei zusätzlichen 30 Sekunden pro Zug von Beginn an.

*Commit 5836116*

Die Deutschen Vereinsmeisterschaften werden bislang mit drei verschiedenen Bedenkzeiten ausgetragen: In den Altersklassen U14, U14w, U16, U20 und U20w wird mit der üblichen Bedenkzeit „Fischer kurz“ gespielt, d.h. 90 Minuten für 40 Züge, danach zusätzliche 30 Minuten für die restlichen Züge, bei zusätzlichen 30 Sekunden pro Zug von Beginn an. Dies ist gemäß JSpO 2.5 die Standardbedenkzeit bei Turnieren der DSJ. Die DVM U12 weicht bislang hiervon ab und wird mit insgesamt 30 Minuten geringerer Grundbedenkzeit ausgetragen, d.h. 75 Minuten für 40 Züge, danach zusätzlich 15 Minuten für die restlichen Züge, bei zusätzlichen 30 Sekunden pro Zug.

In den zurückliegenden Jahren hatte diese kürzere und für die Jugendlichen ungewohnte Bedenkzeit an den vorderen Brettern der DVM U12 bereits negative Auswirkungen auf die Qualität der Partien, Zeitüberschreitungen häufen sich. Bei der DVM U12 im Jahr 2016 hatte die Hälfte der Mannschaften einen DWZ-Schnitt von 1500 und höher, bei fast allen Mannschaften hatte das Spitzenbrett eine DWZ von 1700 oder höher.

Die bislang kürzere Bedenkzeit liegt in der Tradition begründet: Klassisch setzt die DSJ in den jüngeren Altersklassen U10 und U12 kürzere Bedenkzeiten ein. Während dies bei der DEM aufgrund der größeren Rundenzahl im Vergleich zu den älteren Altersklassen auch organisatorische Gründe hat, wird die DVM U12 nach dem gleichen Zeitplan wie die Vereinsmeisterschaften der höheren Altersklassen ausgetragen und lässt problemlos eine Verlängerung der Bedenkzeit zu.

Unabhängig hiervon soll die Offene DVM U10 auch weiterhin mit dem bislang bewährten Modus bei einer Stunde Grundbedenkzeit ausgetragen werden. Dies stellt fortan die einzige Altersklasse mit Abweichungen in der Bedenkzeit dar, die übrigen Altersklassen der DVM würden nach dieser Änderung alle mit dem gleichen Zeitplan ausgetragen.

Der AKS hat sich in seiner Sitzung am 14. Januar 2017 einstimmig für die obige Änderung ausgesprochen. Da es sich um eine Ausführungsbestimmung handelt, wäre die sofortige Verabschiedung möglich gewesen. Aufgrund der übergeordneten Bedeutung und da die Bedenkzeiten grundsätzlich in JSpO 2.5 und nicht in den Ausführungsbestimmungen geregelt sind, wird der Änderungsvorschlag jedoch der Jugendversammlung vorgelegt.