### PR TITLE
Sonneborn-Berger als erste Feinwertung bei Mannschaftsturnieren nach Schweizer System

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -209,10 +209,11 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
 1.  
     Bei Punktgleichheit gelten bei allen Turnieren nach dem Schweizer System die folgenden Kriterien:
-    1.  Anzahl der Brettpunkte,
+    1.  Sonneborn-Berger-Wertung,
     1.  weitere in den Ausführungsbestimmungen festgelegte Feinwertungen.
 
     > Als weitere Feinwertungen werden die folgenden Kriterien in dieser Reihenfolge angewandt:
+    >   1.  Brettpunkte,
     >   1.  Buchholzwertung,
     >   1.  Siegwertung,
     >   1.  direkter Vergleich,


### PR DESCRIPTION
## Antrag an die Jugendversammlung 2017

von der Landesschachjugend Sachsen-Anhalt. [Abgedruckt im JV-Heft zur JV 2017 in Gießen.](http://www.deutsche-schachjugend.de/fileadmin/dsj_image/wir/Verband/JV_2017/Antraege-JV-2017.pdf#page=6)

*Commit f3846b2*

Die geänderte Zweitwertung soll bei Mannschafts-Turnieren im Schweizer System die Stärke der Gegner ebenso berücksichtigen wie die erzielten Brettpunkte. Gerade bei DVM weisen die Teilnehmerfelder oft ein großes Gefälle auf. Leichtere Gegner bieten gleichzeitig sehr viel bessere Chancen auf hohe Brettpunkte, so dass Mannschaften mit "leichterer" Auslosung bei der bisherigen Wertung doppelt bevorteilt sind:
- bessere Möglichkeiten, mehr Mannschaftspunkte zu erzielen 
- Vorteile bei der Zweitwertung

Der Begriff "Sonneborn-Berger-Wertung" ist für Mannschaftsturnier von der FIDE anders definiert, als wir es von Einzelturnieren gewohnt sind. Es werden die erzielten Brettpunkte jedes Matches mit der während des gesamten Turniers erzielten Matchpunktzahl des Gegners multipliziert und dann addiert. So ist gewährleistet, dass sowohl die Stärke der Gegner als auch die Brettpunkte in die Wertung einfließen. 

**Beispiel (Quelle Wikipedia):** 
Einen 2,5:1,5-Sieg gegen einen Gegner mit insgesamt 14 Matchpunkten bewertet die Sonneborn-Berger-Wertung bei Mannschaftsturnieren genauso hoch wie einen 3,5:0,5-Sieg gegen einen Gegner mit insgesamt nur 10 Matchpunkten.
 
Die gängigen Auslosungsprogramme beherrschen diese Wertung seit geraumer Zeit, da sie seit der Schacholympiade 2008 angewendet wird. SwissChess z. B. ab Version 8.88 Natürlich sind damit die Zweitwertungen nicht mehr im Vorhinein ausrechenbar, aber nach unserer Meinung liegt das im Wesen von Turnieren im Schweizer System begründet und gehört bei Einzelturnieren seit Jahren zum gewohnten Bild. Der Vorteil, die Stärke der Gegner im Turnier zu berücksichtigen, wiegt evtl. Nachteile u. E. mehr als auf. 