### PR TITLE
Verweis auf allgemeinen Sanktionskatalog JSpO 3 für Handybetrug o.ä.

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -71,7 +71,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Finden mehrere deutsche Meisterschaften zur gleichen Zeit stand, kann jeder Spieler nur an einer Meisterschaft teilnehmen.
 
-    > Gemäß Art. 11.3 lit. b der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3.1 auszusprechen.
+    > Gemäß Art. 11.3 lit. b der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3 auszusprechen.
 
     > Gemäß Art. 9.1 lit. a der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
 


### PR DESCRIPTION
## Antrag an den AKS

> **AB zu 2.1 (geltende Fassung, Auszug)**
> Gemäß Art. 11.3 lit. b der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3.1 auszusprechen.
> **AB zu 2.1 (neue Fassung, Auszug, Änderung hervorgehoben)**
> Gemäß Art. 11.3 lit. b der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer *3* auszusprechen.

*Commit 0a08d8b*

Der Passus zu 11.3 lit. b der FIDE-Regeln wurde aufgenommen, da dort seit der Änderun-gen 2014 dem Turnierveranstalter die Möglichkeit eingeräumt wird, für Fälle des Mitführens eines Handys oder anderen elektronischen Kommunikationsgeräts mildere Sanktionen als den Partieverlust anzuwenden, sofern dies im Turnierreglement zuvor so festgelegt wurde. Durch den Verweis in AB zu 2.1 auf den JSpO-eigenen Sanktionskatalog in Ziffer 3.1 wird den Schiedsrichtern bei DSJ-Veranstaltungen die Möglichkeit eingeräumt, es bspw. bei einer Ermahnung oder Zeitstrafe zu belassen.

Der Verweis auf JSpO 3.1 ist jedoch zu eng gefasst. Sollte es erwiesen sein, dass ein Spieler mit dem Handy oder einem anderen elektronischen Gerät betrogen hat, ist strittig, ob darüber hinaus noch Spielsperren und Geldbußen über 100 Euro ausgesprochen werden dürften, da diese in JSpO 3.2 benannt sind. Um diese Unklarheit zu beseitigen, soll die Ausführungsbestimmung entsprechend weiter gefasst werden.