### PR TITLE
AB zu 5.7: Aufstellung anwesender Spieler

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -251,7 +251,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Es darf kein Spieler vor einem Spieler aufgestellt werden, der eine um mehr als 200 Punkte bessere DWZ besitzt, es sei denn, die Wertungszahl beider Spieler ist kleiner oder gleich 1000. Über begründete Ausnahmen entscheidet der Turnierverantwortliche.
 
-    > Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
+    > Bei Meisterschaften, die in einem ununterbrochenen Zeitraum am gleichen Ort stattfinden, können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
 
     > Bretter können bei Namensnennung freigelassen werden. Das letzte Brett kann ohne Namensnennung freigelassen werden.
 


### PR DESCRIPTION
> **AB zu 5.7, Absatz 4 (geltende Fassung)**
> 
> Es können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.
> 
> **AB zu 5.7, Absatz 4 (neue Fassung)**
>
> Bei Meisterschaften, die in einem ununterbrochenen Zeitraum am gleichen Ort stattfinden, können in Mannschaftswettkämpfen nur Spieler aufgestellt werden, die vor Ort anwesend sind.

*Commit 6497af49aa87e9de77c3aea3d7f3f954169de602*

Die JSpO gibt an einigen Stellen explizit Regelungen für Turniere auf, die in einem ununterbrochenen Zeitraum am gleichen Ort stattfinden. Dies ist aktuell bei allen DSJ-Mannschaftsmeisterschaften der Fall, gleichwohl hält sich die Ordnung einen Spielbetrieb ähnlich eines Ligensystems mit mehreren Spielterminen offen.

Die genannte Einschränkung auf nur anwesende Spieler erscheint nur bei solchen ununterbrochenen Meisterschaften am gleichen Ort sinnvoll. Weiterhin wird durch den neuen Einschub klar, dass es sich beim zitierten Ort um den Meisterschaftsort handelt, und nicht auf das Turnierareal oder den Spielbereich abgestellt wird.