### PR TITLE
JSpO 1.5: Implizite Festlegung des Turnierverantwortlichen

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -47,7 +47,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Wenn Nachweis über die Voraussetzungen der Spielberechtigung zu führen ist, tritt sie erst mit ihrer Feststellung ein.
 
 1.  
-    Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Wird vom AKS kein Turnierverantwortlicher bestimmt, so ist dies im Vorfeld des Turniers der Nationale Spielleiter und vor Ort ein vom Nationalen Spielleiter benannter Schiedsrichter.
+    Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Wird vom AKS kein Turnierverantwortlicher bestimmt, so ist dies der Nationale Spielleiter oder ein vom Nationalen Spielleiter benannter Schiedsrichter.
 
     > Aus Gründen der Zweckmäßigkeit kann auch eine Person, die nicht Mitglied des AKS ist, als Turnierverantwortlicher benannt werden. Der AKS ist gegenüber dem Turnierverantwortlichen weisungsbefugt.
 

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -47,7 +47,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Wenn Nachweis über die Voraussetzungen der Spielberechtigung zu führen ist, tritt sie erst mit ihrer Feststellung ein.
 
 1.  
-    Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Grundsätzlich wird vom AKS eines seiner Mitglieder bestimmt, das die Vorbereitung eines oder mehrerer Turniere koordiniert.
+    Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Wird vom AKS kein Turnierverantwortlicher bestimmt, so ist dies im Vorfeld des Turniers der Nationale Spielleiter und vor Ort ein vom Nationalen Spielleiter benannter Schiedsrichter.
 
     > Aus Gründen der Zweckmäßigkeit kann auch eine Person, die nicht Mitglied des AKS ist, als Turnierverantwortlicher benannt werden. Der AKS ist gegenüber dem Turnierverantwortlichen weisungsbefugt.
 


### PR DESCRIPTION
> **JSpO 1.5 (geltende Fassung)**
> 
> Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Grundsätzlich wird vom AKS eines seiner Mitglieder bestimmt, das die Vorbereitung eines oder mehrerer Turniere koordiniert.
> 
> **JSpO 1.5 (neue Fassung)**
> 
> Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Wird vom AKS kein Turnierverantwortlicher bestimmt, so ist dies im Vorfeld des Turniers der Nationale Spielleiter und vor Ort ein vom Nationalen Spielleiter benannter Schiedsrichter.

*Commit 0cedb40fde5a7be468a56fd306630fce4dbf5cb9*

Die JSpO unterscheidet zwischen dem Turnierverantwortlichen und Schiedsrichtern. Dem Turnierverantwortlichen obliegt im Vorfeld der Meisterschaft die Organisation. Er verfügt über weitergehende Kompetenzen, die zur Organisation der Meisterschaft notwendig sind, und kann so bspw. genehmigen, dass mehrere Mannschaften von nur einem Betreuer betreut werden.

Die geltende Fassung von JSpO 1.5 spiegelt die Aufgabenverteilung wider, wie sie bis vor einigen Jahren insbesondere bei den DVM üblich war: Es gab für jede Altersklasse einen eigenen DVM-Referenten, der sich um die Organisation der Meisterschaft kümmerte und dann auch jeweils vor Ort war und die ihm eingeräumten besonderen Kompetenzen wahrnehmen konnte. Durch die große technische Unterstützung über das DSJ-Meisterschaftsportal hat sich die Turnierorganisation aber gewandelt und wird so heute in weiten Teilen im Vorfeld der Meisterschaft vom Nationalen Spielleiter vorgenommen. Da dieser nicht selbst bei jeder Meisterschaft anwesend sein kann, werden die dem Turnierverantwortlichen vorbehaltenen Rechte einem Schiedsrichter vor Ort übertragen.

Da auch weiterhin die Möglichkeit bestehen soll, einzelne Meisterschaften in die Verantwortung einer anderen Person zu legen, wird nur der Satz ergänzt, der angewendet wird, falls kein Turnierverantwortlicher vom AKS bestimmt wurde.