### PR TITLE
JSpO 6.5: Kein verpflichtender Freiplatz für DEM-Ausrichter

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -302,11 +302,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > *Übergangsbestimmung in Folge der Trennung in U12/U12w sowie U10/U10w: Zur Berechnung werden alle Jungen der U12, alle Mädchen der U12w zugeordnet; entsprechendes für die U10.*
 
 1.  
-    Der Ausrichter erhält in jeder ausgerichteten Altersklasse einen Freiplatz.
-
     In den Altersklassen U14, U12, U12w, U10 und U10w erhalten alle Kaderspieler in ihrer jeweiligen Altersklasse einen Freiplatz.
 
-    Es können jeweils bis zu zehn weitere Freiplätze vergeben werden. Der AKS kann das Freiplatzkontingent bei außergewöhnlichen Umständen um jeweils bis zu vier weitere Freiplätze erhöhen.
+    Es können jeweils bis zu elf weitere Freiplätze vergeben werden. Der AKS kann das Freiplatzkontingent bei außergewöhnlichen Umständen um jeweils bis zu vier weitere Freiplätze erhöhen.
     
     > Der AKS kann das Freiplatzkontingent erhöhen, wenn in einem Jahr eine außergewöhnlich hohe Zahl von starken Spielern in der jeweiligen Altersklasse zusammenkommt. Eine außergewöhnlich hohe Zahl liegt jedenfalls dann vor, wenn die Zahl der Kaderspieler der Zahl der ordentlichen Freiplätze entspricht oder diese übersteigt.
 


### PR DESCRIPTION
> **JSpO 6.5 (geltende Fassung)**
>
> Der Ausrichter erhält in jeder ausgerichteten Altersklasse einen Freiplatz.
> 
> In den Altersklassen U14, U12, U12w, U10 und U10w erhalten alle Kaderspieler in ihrer jeweiligen Altersklasse einen Freiplatz.
> 
> Es können jeweils bis zu zehn weitere Freiplätze vergeben werden. Der AKS kann das Freiplatzkontingent bei außergewöhnlichen Umständen um jeweils bis zu vier weitere Freiplätze erhöhen.
>
> **JSpO 6.5 (neue Fassung)**
>
> In den Altersklassen U14, U12, U12w, U10 und U10w erhalten alle Kaderspieler in ihrer jeweiligen Altersklasse einen Freiplatz.
> 
> Es können jeweils bis zu elf weitere Freiplätze vergeben werden. Der AKS kann das Freiplatzkontingent bei außergewöhnlichen Umständen um jeweils bis zu vier weitere Freiplätze erhöhen.

*Commit 9b58168f3ff2356a549ea864ed938af8fd9f8188*

Die geltende Fassung stammt noch aus einer Zeit, da die DEM dezentral und mit einer Vielzahl an Ausrichtern stattfand. Wird die DEM heute jedoch zentral von einem einzigen Veranstalter ausgerichtet – wie dies 2014 in Magdeburg der Fall war -, erhält dieser in jeder einzelnen Altersklasse einen Freiplatz. Dies scheint unverhältnismäßig und sollte daher leistungsabhängig entschieden werden. Die Vergabe von Plätzen ist auch weiterhin möglich, dann jedoch in Abwägung der Umstände durch das normale Vergabegremium um den Bundesnachwuchstrainer, Beauftragten für Leistungssport und Nationalen Spielleiter.
Bei solchen DEM, die die DSJ selbst ausgerichtet hat, ist dieser Ausrichterplatz dem normalen Freiplatzkontingent zugutegekommen, die Erhöhung auf bis zu elf weitere Freiplätze passt die Regelung also der üblichen Handhabung an. Die Erhöhung macht auch insofern Sinn, da die betreffenden Altersklassen U14w, U16, U16w, U18 und U18w 19 Qualifikationsplätze vorsehen (17 Landesverbände und je einen für die beiden größten). Das Vergabegremium wird also in der Regel eine ungerade Anzahl von Freiplätzen vergeben wollen, um eine gerade Teilnehmerzahl zu erwirken.
