### PR TITLE
Verweiskorrektur in AB zu 2.1 für FIDE-Regeln ab 01.01.2018

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -75,7 +75,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Gemäß Art. 9.1 lit. a der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
 
-    > Abweichend von Art. 7.5 lit. b und Anhang A4 lit. b der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5 lit. b der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
+    > Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
 
 1.  
     Der Schiedsrichter berücksichtigt bei der Anwendung der FIDE-Regeln den Entwicklungsstand des Spielers und kann in begründeten Ausnahmefällen im Sinne einer altersgemäßen Handhabung von einzelnen Regeln abweichende Entscheidungen treffen.

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -513,7 +513,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
-    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang G4 der FIDE-Regeln findet keine Anwendung.
+    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang III.4 der FIDE-Regeln findet keine Anwendung.
 
 1.  
     Ziffer 9.2 gilt entsprechend.

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -71,9 +71,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Finden mehrere deutsche Meisterschaften zur gleichen Zeit statt, kann jeder Spieler nur an einer Meisterschaft teilnehmen.
 
-    > Gemäß Art. 11.3 lit. b der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3 auszusprechen.
+    > Gemäß Art. 11.3.2 der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3 auszusprechen.
 
-    > Gemäß Art. 9.1 lit. a der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
+    > Gemäß Art. 9.1.1 der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
 
     > Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
 


### PR DESCRIPTION
> **AB zu 2.1 (geltende Fassung, Auszug)**
>
> Gemäß Art. 11.3 lit. b der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3 auszusprechen.
>
> Gemäß Art. 9.1 lit. a der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
>
> Abweichend von Art. 7.5 lit. b und Anhang A4 lit. b der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5 lit. b der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
> 
> **AB zu 2.1 (neue Fassung, Auszug)**
> 
> Gemäß Art. 11.3.2 der FIDE-Regeln ist es Spielern untersagt, ein Mobiltelefon oder anderes elektronisches Gerät in das Turnierareal mitzubringen. Bei Verstößen sind Strafen nach Ziffer 3 auszusprechen.
>
> Gemäß Art. 9.1.1 der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
>
> Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
>
> **AB zu 15.1 (geltende Fassung)**
>
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang G4 der FIDE-Regeln findet keine Anwendung.
>
> **AB zu 15.1 (neue Fassung)**
>
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang III.4 der FIDE-Regeln findet keine Anwendung.

*Commits 4390cca9ed2784f5f350f57116723982d6f1a236 und 1e6bf147373297d1ad3c7870a4fda1bb5acfba44 und 13fbfd134296f07a22b49ff21f5a06d1405e2ef1*

Der referenzierte Artikel ist in der Fassung vom 01.01.2018 in Art. 7.5.5 anzufinden. Ferner wurde Anhang A4 lit. b (jetzt: Anhang A4.2) an Art. 7.5.5 angepasst, sodass dieser nun nicht mehr explizit aufgeführt werden muss.

Die übrigen Änderungen sind ausschließlich Anpassungen an die geänderte Nummerierung in den seit seit 01.07.2017 gültigen FIDE-Regeln.