### PR TITLE
Ausweitung Euregio auf alle DSJ-Meisterschaften

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -416,7 +416,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Für die Spielberechtigung der laufenden Saison ist grundsätzlich der Passschreibungstermin (in der Regel 15. Juli) des laufenden Jahres der DVM maßgeblich; zu einem anderen Zeitpunkt in Kraft getretene Spielberechtigungen sind von dem Verein nachzuweisen.
 
 1.  
-    Abweichend zu 8.2 und 8.3 wird die DVM U20w als offenes Turnier ausgetragen. 8.5 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 16 Plätze angeboten werden sollen. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U20.
+    Abweichend zu 8.2 wird die DVM U20w als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 16 Plätze angeboten werden sollen. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U20.
 
     > Sofern eine Beschränkung der Teilnehmerzahl erfolgt, kann der Turnierverantwortliche unter Berücksichtigung folgender Kriterien Plätze vergeben:
     >   *   Reihenfolge der Anmeldungen
@@ -518,7 +518,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U10 [Jahreszahl]".
 
 1.  
-    Abweichend zu 8.2 und 8.3 wird die DVM U10 als offenes Turnier ausgetragen. 8.5 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze.
+    Abweichend zu 8.2 wird die DVM U10 als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze.
 
     > Ziel ist es, dass alle interessierten Vereine mit einer Mannschaft teilnehmen können. Wenn die Kapazitäten ausreichen, sind mehrere Mannschaften eines Vereins zulässig. Sind die Kapazitäten beschränkt, vergibt der Turnierverantwortliche Freiplätze. In diesem Falle melden die Länder dem Turnierverantwortlichen bis zum 01.11. einen Verein ihres Landes, der auf jeden Fall startberechtigt ist.
 

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -38,13 +38,16 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     An diesen Veranstaltungen können nur Jugendliche teilnehmen, die durch ihre Mitgliedsorganisation dem Deutschen Schachbund (DSB) gemeldet sind. Sie müssen
     1.  die deutsche Staatsangehörigkeit besitzen oder
     1.  seit mindestens einem Jahr ihren Lebensmittelpunkt in der Bundesrepublik Deutschland haben oder
+    1.  erstens seit mindestens einem Jahr ihren Lebensmittelpunkt in einem Gebiet entlang der Grenzen zur Bundesrepublik Deutschland haben, das auf Verwaltungsebene III der Nomenklatur statistischer Gebietseinheiten abgegrenzt ist, und zweitens in keinem ausländischen Schachverein Mitglied sein, oder
     1.  teilnahmeberechtigt sein aufgrund einer anderen Bestimmung dieser Ordnung.
     
-    Sofern nichts anderes bestimmt ist, sind dem Nationalen Spielleiter die Voraussetzungen nur auf seine Anforderung nachzuweisen.
+    Sofern nichts anderes bestimmt ist, sind in den Fällen der Nr. 3 die Voraussetzungen dem Nationalen Spielleiter immer, in den anderen Fällen nur auf seine Anforderung nachzuweisen.
 
-    > Zum Nachweis des Lebensmittelpunkts dienen Melde-, Schul- bzw. Ausbildungsbescheinigung oder andere amtliche Bescheinigungen.
+    > Zum Nachweis des Lebensmittelpunkts dienen Melde-, Schul- bzw. Ausbildungsbescheinigung oder andere amtliche Bescheinigungen. Zum Nachweis, dass keine Mitgliedschaft in einem ausländischen Verein besteht, unterzeichnen der Verein, der Jugendliche und ggf. seine gesetzlichen Vertreter eine entsprechende Erklärung.
 
     > Wenn Nachweis über die Voraussetzungen der Spielberechtigung zu führen ist, tritt sie erst mit ihrer Feststellung ein.
+
+    > *Die Verwaltungsebene III entspricht den deutschen Landkreisen. Die Gebiete sind jene, die förderfähig im Europa-Programm Interreg III A (z.B. bekannt als "Euregio") sind. Die Gebiete sind aufgeführt in Anhang I der Mitteilung der EU-Kommission 2004/C 226/02, wobei jeweils zu prüfen ist, ob eine gemeinsame Grenze mit der Bundesrepublik Deutschland besteht. Die Mitteilung ist auf der DSJ-Internetseite verfügbar.*
 
 1.  
     Der Arbeitskreis Spielbetrieb (AKS) unter Leitung des Nationalen Spielleiters ist zuständig für die Austragung aller von der DSJ ausgeschriebenen Turniere. Die Vorbereitung und Turnierleitung obliegt einer vom Arbeitskreis Spielbetrieb (AKS) bestimmten, fachlich geeigneten Person ("Turnierverantwortlicher"); aus Gründen der Zweckmäßigkeit können die Vorbereitung der Turniere und die Turnierleitung vor Ort auf mehrere Personen verteilt werden. Grundsätzlich wird vom AKS eines seiner Mitglieder bestimmt, das die Vorbereitung eines oder mehrerer Turniere koordiniert.
@@ -352,13 +355,6 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     Bei den DVM sind je Mannschaft grundsätzlich die Spieler startberechtigt, die in der der DVM vorangegangenen Saison für diesen Verein spielberechtigt waren. Spieler, die in ebendieser Saison für keinen Verein spielberechtigt waren, sind nur für den Verein startberechtigt, für den sie zum Zeitpunkt der DVM spielberechtigt sind.
 
     > Für die Spielberechtigung der der DVM vorangegangenen Saison ist grundsätzlich der Passschreibungstermin (in der Regel 15. Juli) des Vorjahres der DVM maßgeblich; zu einem anderen Zeitpunkt in Kraft getretene Spielberechtigungen sind von dem Verein nachzuweisen.
-
-1.  
-    Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind zusätzlich Jugendliche, die erstens seit mindestens einem Jahr ihren Lebensmittelpunkt in einem Gebiet entlang der Grenzen zur Bundesrepublik Deutschland haben, das auf Verwaltungsebene III der Nomenklatur statistischer Gebietseinheiten abgegrenzt ist, und zweitens in keinem ausländischen Schachverein Mitglied sind. Die Voraussetzungen sind dem Nationalen Spielleiter nachzuweisen. 8.1 Satz 2 findet keine Anwendung.
-
-    > Zum Nachweis, dass keine Mitgliedschaft in einem ausländischen Verein besteht, unterzeichnen der Verein, der Jugendliche und ggf. seine gesetzlichen Vertreter eine entsprechende Erklärung.
-
-    > *Die Verwaltungsebene III entspricht den deutschen Landkreisen. Die Gebiete sind jene, die förderfähig im Europa-Programm Interreg III A (z.B. bekannt als "Euregio") sind. Die Gebiete sind aufgeführt in Anhang I der Mitteilung der EU-Kommission 2004/C 226/02, wobei jeweils zu prüfen ist, ob eine gemeinsame Grenze mit der Bundesrepublik Deutschland besteht. Die Mitteilung ist auf der DSJ-Internetseite verfügbar.*
 
 1.  
     Zur Ermittlung der teilnehmenden Mannschaften werden folgende Regionalgruppen gebildet:

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -507,7 +507,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
 
 1.  
-    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
+    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang G4 der FIDE-Regeln findet keine Anwendung.
 


### PR DESCRIPTION
Die Spielberechtigung für Jugendliche des sogenannten „Euregio“-Gebiets entlang der Grenzen zur Bundesrepublik Deutschland ist bereits seit mehreren Jahren für die DVM in JSpO 8.2 geregelt. Nachdem sich die Jugendversammlung im vergangenen Jahr grundsätzlich positiv gegenüber einer Ausweitung auf alle Meisterschaften positioniert hat, beantragt der AKS nun diese Änderung. Zum Zwecke der Übersichtlichkeit sind die hierfür notwendigen Ordnungsänderungen im Antrag (a) zusammengefasst; die sich daraus ergebenden Korrekturen von Referenzen sind im Antrag (b) zusammengefasst. Antrag (a) führt die notwendigen Ordnungsänderungen nicht in ihrer Textreihenfolge auf, sondern in der Form „Streiche den DVM-Teil und füge ihn im allgemeinen Teil ein“. Eine Fassung, wie die Jugendspielordnung nach Annahme der Anträge 3 und 4 aussähe, findet sich unter http://schachjugend.org/jv18. Die Anträge (a) und (b) werden gemeinsam zur Abstimmung gestellt.

## (a) Ausweitung der Euregio-Spielberechtigung

> **JSpO 8.2 [Abschnitt „Allgemeine Bestimmungen zu den DVM“]  (geltende Fassung, zu streichen)**
> Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind zusätzlich Jugendliche, die erstens seit mindestens einem Jahr ihren Lebensmittelpunkt in einem Gebiet entlang der Grenzen zur Bundesrepublik Deutschland haben, das auf Verwaltungsebene III der Nomenklatur statistischer Gebietseinheiten abgegrenzt ist, und zweitens in keinem ausländischen Schachverein Mitglied sind. Die Voraussetzungen sind dem Nationalen Spielleiter nachzuweisen. 8.1 Satz 2 findet keine Anwendung.
> **AB zu JSpO 8.2 (geltende Fassung, zu streichen)**
> Zum Nachweis, dass keine Mitgliedschaft in einem ausländischen Verein besteht, unterzeichnen der Verein, der Jugendliche und ggf. seine gesetzlichen Vertreter eine entsprechende Erklärung.
Die Verwaltungsebene III entspricht den deutschen Landkreisen. Die Gebiete sind jene, die förderfähig im Europa-Programm Interreg III A (z.B. bekannt als "Euregio") sind. Die Gebiete sind aufgeführt in Anhang I der Mitteilung der EU-Kommission 2004/C 226/02, wobei jeweils zu prüfen ist, ob eine gemeinsame Grenze mit der Bundesrepublik Deutschland besteht. Die Mitteilung ist auf der DSJ-Internetseite verfügbar.
> **Die alten Nummern 8.3 bis 8.5 verringern sich um 1.**
> **JSpO 1.4 (geltende Fassung)**
> An diesen Veranstaltungen können nur Jugendliche teilnehmen, die durch ihre Mitgliedsorganisation dem Deutschen Schachbund (DSB) gemeldet sind. Sie müssen
> 1.   die deutsche Staatsangehörigkeit besitzen oder
> 1.   seit mindestens einem Jahr ihren Lebensmittelpunkt in der Bundesrepublik Deutschland haben oder
> 1.   teilnahmeberechtigt sein aufgrund einer anderen Bestimmung dieser Ordnung.
>
> Sofern nichts anderes bestimmt ist, sind dem Nationalen Spielleiter die Voraussetzungen nur auf seine Anforderung nachzuweisen.
> **JSpO 1.4 (neue Fassung)**
> An diesen Veranstaltungen können nur Jugendliche teilnehmen, die durch ihre Mitgliedsorganisation dem Deutschen Schachbund (DSB) gemeldet sind. Sie müssen
> 1. die deutsche Staatsangehörigkeit besitzen oder
> 1. seit mindestens einem Jahr ihren Lebensmittelpunkt in der Bundesrepublik Deutschland haben oder
> 1. erstens seit mindestens einem Jahr ihren Lebensmittelpunkt in einem Gebiet entlang der Grenzen zur Bundesrepublik Deutschland haben, das auf Verwaltungsebene III der Nomenklatur statistischer Gebietseinheiten abgegrenzt ist, und zweitens in keinem ausländischen Schachverein Mitglied sein, oder
> 1. teilnahmeberechtigt sein aufgrund einer anderen Bestimmung dieser Ordnung.
> 
> Sofern nichts anderes bestimmt ist, sind in den Fällen der Nr. 3 die Voraussetzungen dem Nationalen Spielleiter immer, in den anderen Fällen nur auf seine Anforderung nachzuweisen.
> **AB zu JSpO 1.4 (geltende Fassung)**
> Zum Nachweis des Lebensmittelpunkts dienen Melde-, Schul- bzw. Ausbildungsbescheinigung oder andere amtliche Bescheinigungen.
Wenn Nachweis über die Voraussetzungen der Spielberechtigung zu führen ist, tritt sie erst mit ihrer Feststellung ein. 
> **AB zu JSpO 1.4 (neue Fassung)**
> Zum Nachweis des Lebensmittelpunkts dienen Melde-, Schul- bzw. Ausbildungsbescheinigung oder andere amtliche Bescheinigungen. Zum Nachweis, dass keine Mitgliedschaft in einem ausländischen Verein besteht, unterzeichnen der Verein, der Jugendliche und ggf. seine gesetzlichen Vertreter eine entsprechende Erklärung.
Wenn Nachweis über die Voraussetzungen der Spielberechtigung zu führen ist, tritt sie erst mit ihrer Feststellung ein.
Die Verwaltungsebene III entspricht den deutschen Landkreisen. Die Gebiete sind jene, die förderfähig im Europa-Programm Interreg III A (z.B. bekannt als "Euregio") sind. Die Gebiete sind aufgeführt in Anhang I der Mitteilung der EU-Kommission 2004/C 226/02, wobei jeweils zu prüfen ist, ob eine gemeinsame Grenze mit der Bundesrepublik Deutschland besteht. Die Mitteilung ist auf der DSJ-Internetseite verfügbar.

## (b) Korrektur von Verweisen

> **JSpO 10.2 [Abschnitt „DVM U20w“] (geltende Fassung)**
> Abweichend zu 8.2 und 8.3 wird die DVM U20w als offenes Turnier ausgetragen. 8.5 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 16 Plätze angeboten werden sollen. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U20.
> **JSpO 10.2 (neue Fassung)**
> Abweichend zu 8.2 wird die DVM U20w als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 16 Plätze angeboten werden sollen. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U20. 
> **JSpO 15.1 [Abschnitt „DVM U10“] (geltende Fassung)**
> An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind. 
> **JSpO 15.1 (neue Fassung)**
> An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind. 
> **JSpO 15.4 [Abschnitt „DVM U10“] (geltende Fassung)**
> Abweichend zu 8.2 und 8.3 wird die DVM U10 als offenes Turnier ausgetragen. 8.5 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze. 
> **JSpO 15.4 (neue Fassung)**
> Abweichend zu 8.2 wird die DVM U10 als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze.

## Begründung

Die starre Wirkung von Grenzen stammt noch aus einer Zeit, als Zölle und Passkontrollen bei ihrem Übertritt fällig waren. Heute weist gerade ein Schild auf den Grenzübertritt hin, häufig ist die Währung die gleiche – die ehemals strukturschwachen Randgebiete der Nachbarländer wachsen zusammen. So gibt es auch immer mehr Fälle, wo die Ländergrenzen im Alltag so sehr verschwinden, dass das Leben gleichermaßen dies- und jenseits des Grenzpfahls stattfindet: Schule hier, Wohnung dort – und der Schachverein eben im DSB. Haben diese Spieler einen so deutlich geringeren Bezug zum deutschen Schachwesen, dass sie anders zu behandeln sind als jene Spieler mit ausländischer Staatsbürgerschaft, deren Lebensmittelpunkt in der Bundesrepublik liegt?
Bei der Jugendversammlung 2017 wurden die Voraussetzungen für die Spielberechtigung bei Deutschen Meisterschaften intensiv diskutiert. Bereits jetzt haben einige Landesverbände die Regelung, wie sie auf DSJ-Ebene bislang nur für die DVM gilt, für all ihre Meisterschaften übernommen. So ist es dort möglich, an einer Landesmeisterschaft teilzunehmen, obwohl man nicht die deutsche Staatsbürgerschaft und seinen Lebensmittelpunkt auch nicht in Deutschland hat, wohl aber in einer an Deutschland angrenzenden Region.
Gerade für diese Jugendlichen wird die bestehende Regelung aber zum Nachteil. Sie sind derzeit nur für die DVM spielberechtigt, für die DLM und DEM jedoch nicht. Aufgrund der Einschränkung, dass diese Jugendlichen nicht zugleich Mitglied in einem ausländischen Verein sein dürfen, wird ihnen de facto die Teilnahme an einer Einzel- oder Ländermeisterschaft verwehrt. Einziger Ausweg? Doch dem deutschen Schachverein, dem sie bereits verbunden sind, den Rücken kehren, damit man eben auch mal bei nationalen Einzelmeisterschaften teilnehmen kann. Aus Sicht des AKS spricht nichts dagegen, ihnen stattdessen auch die Teilnahmemöglichkeit an DEM und DLM zu gewähren.
Der vorliegende Vorschlag sichert den Bezug zum deutschen Schach auf zwei Arten:
1.   Regionaler Bezug
     Nur Spieler mit Wohnsitz in den die deutsche Grenze berührenden ausländischen Landkreisen können in den Genuss der Regelung kommen. Dies sind die als Euregio bekannten Fördergebiete der EU, die Formulierung ist der entsprechenden Rechtsgrundlage entlehnt und hat sich bereits für die DVM als sinnvoll erwiesen.
1.   Ausschließliche Mitgliedschaft im DSB
      Nur Spieler, die nicht Mitglied in einem Schachverein ihres Landes (oder auch eines anderen, wie es in den Dreiländerecken vorstellbar ist) sind, sollen zugelassen sein. Damit besteht für die Spieler nur eine subsidiäre Möglichkeit, am regelmäßigen Spielbetrieb in Deutschland teilzunehmen. Ein Doppelspiel ist nicht möglich – der Spieler muss sich entscheiden.
In dieser Hinsicht sind die Spieler der Euregio-Region schlechter gestellt als Spieler mit deutscher Staatsbürgerschaft und solchen, die seit mindestens einem Jahr ihren Lebensmittelpunkt in Deutschland haben. Diese dürften auch am ausländischen Spielbetrieb teilnehmen, ohne ihre Spielberechtigung für die Deutschen Meisterschaften zu verlieren. 

Bei den vorgeschlagenen Änderungen werden die Teile zur Euregio-Spielberechtigung einzig vom DVM-spezifischen Teil der Jugendspielordnung in den allgemeinen verschoben. Der ursprünglich in JSpO 8.2 geführte Satz „8.1 Satz 2 findet keine Anwendung.“ wird dagegen gestrichen. Er sollte ursprünglich erzwingen, dass Jugendliche vor einer DVM-Teilnahme mindestens anderthalb Jahre Mitglied in diesem Verein waren. Dies erscheint erstens unverhältnismäßig streng im Vergleich zur sehr viel liberaleren Regelung für alle Spieler, die diesseits der Landesgrenze wohnen. Andererseits macht die Einschränkung, da die Euregio-Spielberechtigung für alle Meisterschaften erteilt wird, einzig für die DVM wenig Sinn.

## Verlauf

1.   Auf der Jugendversammlung 2004 wurden die Deutschen Meisterschaften für Jugendliche ohne deutsche Staatsbürgerschaft geöffnet, sofern diese seit mindestens einem Jahr ihren Lebensmittelpunkt in Deutschland haben.
1.    Der Arbeitskreis Spielbetrieb (AKS) hat zur Jugendversammlung 2009 einen Antrag gestellt, alle Deutschen Meisterschaften für ausländische Jugendliche aus grenznahen Regionen zu öffnen. De facto entspricht der nun vorliegende Antrag inhaltlich dem aus 2009.
       Die Jugendversammlung hat den Antrag diskutiert und in ihrem Meinungsbild ihre grundsätzlich positive Einstellung unterstrichen. In 2009 bestanden allerdings mehrheitlich Vorbehalte gegen eine Öffnung aller Meisterschaften.
1.    Auf der Jugendversammlung 2010 wurde die seitdem geltende Öffnung für die DVM beschlossen.
1.    Auf der Jugendversammlung 2017 wurde erneut ein Meinungsbild der Länder eingeholt, die sich nun mehrheitlich für die Ausweitung der bestehenden Öffnung auf alle Deutschen Meisterschaften aussprachen.
1.    Im vorliegenden Antrag stellt der AKS diese Öffnung nun zur Abstimmung.