### PR TITLE
Einzelfallprüfung zur Teilnahmeberechtigung an Deutschen Meisterschaften

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -361,6 +361,13 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > *Die Verwaltungsebene III entspricht den deutschen Landkreisen. Die Gebiete sind jene, die förderfähig im Europa-Programm Interreg III A (z.B. bekannt als "Euregio") sind. Die Gebiete sind aufgeführt in Anhang I der Mitteilung der EU-Kommission 2004/C 226/02, wobei jeweils zu prüfen ist, ob eine gemeinsame Grenze mit der Bundesrepublik Deutschland besteht. Die Mitteilung ist auf der DSJ-Internetseite verfügbar.*
 
 1.  
+    Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind auf begründeten Antrag zusätzlich Jugendliche, die
+    1.  ihren bisherigen Lebensmittelpunkt aufgegeben und nun in der Bundesrepublik Deutschland haben oder
+    1.  in der Vergangenheit bereits teilnahmeberechtigt waren nach 1.4 Satz 2 Nr. 2 und an Turnieren nach 1.3 teilgenommen haben.
+
+    > Dem Antrag ist zu entsprechen, falls der Jugendliche einen starken Bezug zum deutschen Schach hat. Die Entscheidung hierüber trifft der Vorstand. Er berücksichtigt bei seiner Entscheidung die Einschätzung des Landesverbands, sofern sie vorliegt.
+
+1.  
     Zur Ermittlung der teilnehmenden Mannschaften werden folgende Regionalgruppen gebildet:
 
     Nord: Berlin, Brandenburg, Bremen, Hamburg, Mecklenburg-Vorpommern, Niedersachsen, Sachsen-Anhalt, Schleswig-Holstein;


### PR DESCRIPTION
> **JSpO 1.5 (neu einzufügen)**
> Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 3 sind auf begründeten Antrag zusätzlich Jugendliche, die
> 1.	ihren bisherigen Lebensmittelpunkt aufgegeben und nun in der Bundesrepublik Deutschland haben oder
> 2.	in der Vergangenheit bereits teilnahmeberechtigt waren nach 1.4 Satz 2 Nr. 2 und an Turnieren nach 1.3 teilgenommen haben.
> 
> **Die alten Nummern 1.5 bis 1.7 erhöhen sich um 1.**
> 
> **AB zu 1.5 (neu einzufügen)**
> Dem Antrag ist zu entsprechen, falls der Jugendliche einen starken Bezug zum deutschen Schach hat. Die Entscheidung hierüber trifft der Vorstand. Er berücksichtigt bei seiner Entscheidung die Einschätzung des Landesverbands, sofern sie vorliegt.

In der jüngsten Vergangenheit ist es zu zwei Härtefällen gekommen, bei denen Jugendliche auf-grund den strengen Anforderungen der JSpO 1.4 nicht zu Deutschen Meisterschaften zugelassen werden durften, obwohl sie einen starken Bezug zum deutschen Schach aufwiesen. In dem einen Fall wurde die Jahresfrist nach 1.4 Satz 2 Nr. 2 um einen einzigen Tag unterschritten, der Jugendliche hatte aber gleichwohl in der Zwischenzeit aktiv am Vereinsleben teilgenommen und hätte sich mglw. sogar die Qualifikation zur Deutschen Meisterschaft erspielt. Im dem anderen Fall musste ein Jugendlicher ohne deutsche Staatsbürgerschaft, der seit vielen Jahren in Deutschland lebt und an mehreren Deutschen Meisterschaften teilgenommen hat, bei der Entscheidung um ein Auslandssemester abwägen, ob er seine Spielberechtigung nach 1.4 Satz 2 Nr. 2 aufgibt.

Beide Fälle eint, dass eine Einzelfallprüfung der Frage, ob die Spielberechtigung aufgrund der Verbundenheit zum deutschen Schach erteilt werden kann, auf breite Zustimmung getroffen wäre. Unsere Spielordnung sieht eine solche derzeit allerdings nicht vor. Auf der Jugendversammlung 2017 wurde daher ein Meinungsbild der Länder eingeholt, ob eine solche Einzelfallprüfung zukünftig erlaubt werden soll, was mehrheitlich bejaht wurde.
Der Arbeitskreis Spielbetrieb hält grundsätzlich weiter an der in 1.4 geforderten Jahresfrist fest. Die Antragsteller haben daher zu begründen, wodurch der starke Bezug zum deutschen Schach auch bei einer geringeren Zeitspanne gegeben ist. Aufgrund der neuen Regel wird dieser zumindest eher vermutet für Jugendliche, die aufgrund von Einwanderung keine Bindung zum Schach am Ort ihres bisherigen Lebensmittelpunkts haben, sowie für solche, die bereits in der Vergangenheit ihren Lebensmittelpunkt in Deutschland hatten und an Deutschen Meisterschaften („Turniere nach 1.3“) teilgenommen haben.

Die Entscheidung über den Antrag trifft der Vorstand der DSJ. Die Entscheidung erfolgt im Zuge der Prüfung der Spielberechtigung, welche in der Regel vier bis sechs Wochen vor der Meisterschaft erfolgt. Es soll die Meinung des Landesverbands eingeholt werden, da dieser von der Entscheidung mittelbar betroffen ist und die Verbundenheit zum deutschen Schach bestätigen kann. Die Entscheidung des Vorstandes kann auf dem normalen Protestwege vom DSJ-Schiedsgericht geprüft werden.

Falls [Antrag 3 zur Ausweitung der Euregio-Regelung](https://github.com/Schachjugend/Spielordnung/pull/47) angenommen wird, ist der Verweis in Satz 1 entsprechend zu „… im Sinne von 1.4 Satz 2 Nr. 4…“ abzuändern.
