### PR TITLE
AB zu 16.1 (DSM): Anpassungen an neue FIDE-Regeln

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -537,7 +537,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Es gelten die FIDE-Regeln (Anhang A: Schnellschach) mit folgenden Abweichungen:
     >   *   Ein Spieler hat die Partie verloren, wenn er nach der Erklärung des Schiedsrichters, die Runde sei eröffnet, im Spielbereich eintrifft (Null Karenz).
     >   *   Abweichend von Anhang A.2 der FIDE-Regeln besteht Notationspflicht bis 5 Minuten vor Plättchenfall. Ausgenommen sind die Altersklassen WK IV, G und HR.
-    >   *   Der Anhang III.4 der FIDE-Regeln zur Endspurtphase findet keine Anwendung. Der Schiedsrichter darf jedoch eine Partie, bei der ein Spieler keine Gewinnversuche unternimmt, oder bei technischen Remis (z.B. König und Springer gegen König) remis geben.
+    >   *   Der Anhang III.4 der FIDE-Regeln zur Endspurtphase findet keine Anwendung. Der Schiedsrichter darf jedoch eine Partie, bei der ein Spieler keine Gewinnversuche unternimmt, oder bei technischen Remis remis geben.
 
 1.  
     Spielberechtigt sind

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -536,9 +536,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Es gelten die FIDE-Regeln (Anhang A: Schnellschach) mit folgenden Abweichungen:
     >   *   Ein Spieler hat die Partie verloren, wenn er nach der Erklärung des Schiedsrichters, die Runde sei eröffnet, im Spielbereich eintrifft (Null Karenz).
-    >   *   Abweichend von Anhang A2 der FIDE-Regeln besteht Notationspflicht bis 5 Minuten vor Plättchenfall. Ausgenommen sind die Altersklassen WK IV, G und HR.
-    >   *   Abweichend von Anhang A4 lit. b der FIDE-Regeln führt der Abschluss eines unmöglichen Zuges nicht zum Verlust der Partie. Es gelten insoweit die Regeln des Turnierschachs (Art. 7.5).
-    >   *   Der Anhang G der FIDE-Regeln (Endspurtphase) findet keine Anwendung. Der Schiedsrichter darf jedoch eine Partie, bei der ein Spieler keine Gewinnversuche unternimmt, oder bei technischen Remis (z.B. König und Springer gegen König) remis geben.
+    >   *   Abweichend von Anhang A.2 der FIDE-Regeln besteht Notationspflicht bis 5 Minuten vor Plättchenfall. Ausgenommen sind die Altersklassen WK IV, G und HR.
+    >   *   Der Anhang III.4 der FIDE-Regeln zur Endspurtphase findet keine Anwendung. Der Schiedsrichter darf jedoch eine Partie, bei der ein Spieler keine Gewinnversuche unternimmt, oder bei technischen Remis (z.B. König und Springer gegen König) remis geben.
 
 1.  
     Spielberechtigt sind


### PR DESCRIPTION
Mit den FIDE-Regeln vom 01.07.2017 haben sich die referenzierten Artikel etwas verschoben.
Anhang A2 wird nun als A.2 geführt, Anhang G wurde durch die Richtlinie in III.4 ersetzt.
In den Neuerungen der FIDE-Regeln vom 01.01.2018 wurden die Schnellschachregeln zudem
dem Turnierschach angeglichen. Den ehemaligen A4 lit. b, der im Schnellschach zum sofortigen
Partieverlust nach einem regelwidrigen Zug führte, gibt es nicht mehr. Stattdessen verliert auch
im Schnellschach erst der zweite regelwidrige Zug, sodass der Verweis in AB zu 16.1 entfernt
werden kann. Dies hat die DSJ außerdem in AB zu 2.1 weiter entschärft, sodass grundsätzlich
erst der dritte regelwidrige Zug die Partie verliert. Da JSpO 2.2 zudem die Abweichung für junge
und unerfahrene Spieler zulässt, ist bei den Schulschachmeisterschaften, wo mitunter auch sehr
unerfahrene Kinder mitspielen, auch eine noch weniger strenge Handhabung möglich. Der bishe-
rige Verweis in AB zu 16.1 erübrigt sich daher und kann gestrichen werden.
Das Beispiel „König und Springer gegen König“ ist wenig sinnvoll, da eine solche Stellung auf-
grund von FIDE-Regel 5.2.2 bereits eine tote Stellung ist und die Partie damit beendet ist. Der
Sinn der Regel wird auch ohne dieses Beispiel deutlich.