### PR TITLE
DVM U10: Meisterschaft mit Qualifikationsplätzen

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -512,7 +512,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
 
 1.  
-    An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
+    An der DVM U10 nehmen 40 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang III.4 der FIDE-Regeln findet keine Anwendung.
 
@@ -523,10 +523,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U10 [Jahreszahl]".
 
 1.  
-    Abweichend zu 8.2 wird die DVM U10 als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze.
+    Abweichend zu 8.2 und 8.3 ergibt sich das Teilnehmerfeld wie folgt: Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Landesverbände verteilt. Das Nähere regeln die Ausführungsbestimmungen.
 
-    > Ziel ist es, dass alle interessierten Vereine mit einer Mannschaft teilnehmen können. Wenn die Kapazitäten ausreichen, sind mehrere Mannschaften eines Vereins zulässig. Sind die Kapazitäten beschränkt, vergibt der Turnierverantwortliche Freiplätze. In diesem Falle melden die Länder dem Turnierverantwortlichen bis zum 01.11. einen Verein ihres Landes, der auf jeden Fall startberechtigt ist.
-
+    > AB zu 8.3 gilt entsprechend für die Landesverbände.
 
 ## 16. DSM
 


### PR DESCRIPTION
Der Arbeitskreis Spielbetrieb strebt die Entwicklung der DVM U10 hin zu einer Meisterschaft mit 40 Qualifikationsplätzen an. Es werden zwei Varianten vorgeschlagen, wie diese verteilt werden könnten: Antrag (a) behandelt die Vergabe der Plätze über Regionalgruppen, Antrag (b) die Vergabe direkt über die Landesverbände. Es handelt sich um konkurrierende Anträge. Die Referenzen zu 1.4, 8.2 und 8.4 beziehen sich auf die Nummerierung nach Genehmigung von Antrag 3 (b) und sind andernfalls entsprechend zu ersetzen.

## (a) Qualifikation über Regionalgruppen

> **JSpO 15.1 (geltende Fassung)**
> An der DVM U10 nehmen Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
> **JSpO 15.1 (geltende Fassung)**
> An der DVM U10 nehmen 40 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10.
> **JSpO 15.4 (geltende Fassung, zu streichen)**
> Abweichend zu 8.2 wird die DVM U10 als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze.
> **AB zu 15.4 (geltende Fassung, zu streichen)**
> Ziel ist es, dass alle interessierten Vereine mit einer Mannschaft teilnehmen können. Wenn die Kapazitäten ausreichen, sind mehrere Mannschaften eines Vereins zulässig. Sind die Kapazitäten beschränkt, vergibt der Turnierverantwortliche Freiplätze. In diesem Falle melden die Länder dem Turnierverantwortlichen bis zum 01.11. einen Verein ihres Landes, der auf jeden Fall startberechtigt ist.

Die Änderung soll 2019 zur erstmaligen Anwendung kommen.

## (b) Qualifikation über Landesverbände

> **JSpO 15.4 (geltende Fassung)**
> Abweichend zu 8.2 wird die DVM U10 als offenes Turnier ausgetragen. 8.4 findet keine Anwendung. Die Teilnehmerzahl kann beschränkt werden, wobei mindestens 25 Plätze angeboten werden sollen. Jeder Landesverband bekommt mindestens einen Platz, dazu gibt es Freiplätze.
> **JSpO 15.4 (neue Fassung)**
> Abweichend zu 8.2 und 8.3 ergibt sich das Teilnehmerfeld wie folgt: Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Landesverbände verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
> **AB zu 15.4 (geltende Fassung)**
> Ziel ist es, dass alle interessierten Vereine mit einer Mannschaft teilnehmen können. Wenn die Kapazitäten ausreichen, sind mehrere Mannschaften eines Vereins zulässig. Sind die Kapazitäten beschränkt, vergibt der Turnierverantwortliche Freiplätze. In diesem Falle melden die Länder dem Turnierverantwortlichen bis zum 01.11. einen Verein ihres Landes, der auf jeden Fall startberechtigt ist.
> **AB zu 15.4 (neue Fassung)**
> AB zu 8.2 gilt entsprechend für die Landesverbände.

Die Änderung soll 2019 zur erstmaligen Anwendung kommen.

## Begründung

Die Offene DVM U10 erfreut sich seit Jahren steigender Beliebtheit. Im vergangenen Jahr nahmen nach Aufhebung der Teilnehmergrenze 80 Mannschaften aus 59 Vereinen teil. Die Meisterschaft wird damit Opfer ihres eigenen Erfolgs: In dieser Größe ist ein siebenrundiges Turnier wenig aussagekräftig, daneben ist die Turniergröße nur noch schwer händelbar, aufgrund der Größe werden Alternativen zum langjährigen Ausrichter in Magdeburg rar. Selbst wenn man nur auf eine Mannschaft je Verein abstellt, ist 2018 mit einer Turniergröße von 70 Teams zu rechnen.
Der Arbeitskreis Spielbetrieb hat die Vereine von 2017 in einer Umfrage befragt und zukünftige Modelle ausgelotet. Die Ergebnisse der Umfrage sind öffentlich und auf http://schachjugend.org/jv18 verlinkt. Darin finden sich auch weitere diskutierte Zukunftsmodelle.
Der AKS kam darin überein, dass ein solches Event, wie es derzeit alljährlich in Magdeburg geboten wird, für die Teilnehmenden einmalig ist und erhalten werden sollte. Dennoch erfordern die oben genannten Probleme ein Umdenken hin zu einer Meisterschaft mit Qualifikation, so wie es in den höheren Altersklassen auch der Fall ist. Diese soll mit 40 Teams noch immer einen deutlich größeren Charakter tragen als die Meisterschaften ab U12, die mit 20 Mannschaften ausgespielt werden. Für den Fall, dass der Ausrichter über genügend Kapazität verfügt, soll daneben weiterhin ein offenes U10-Mannschaftsturnier angeboten. Für Magdeburg wären also auch weiterhin 60 oder gar mehr Teams denkbar; für andere Vereine und Verbände könnte das auf 40 Mannschaften begrenzte Turnier aber nun wieder attraktiver zur Ausrichtung werden.
Für das Verteilen der 40 Qualifikationsplätze kommen zwei Modelle in Frage: (a) wie in den übrigen Altersklassen über die Regionalgruppen, oder (b) direkt an die Landesverbände. Der AKS sah Vor- und Nachteile für beide Modelle und gibt daher der Jugendversammlung die Gelegenheit, über diese Ausgestaltung abzustimmen.
Aufgrund der bereits vorgenommenen DVM-Ausrichtervergabe für 2018 und damit die Länder bzw. Regionalgruppen Gelegenheit erhalten, ihre Qualifikationsturniere entsprechend zu planen, soll die Änderung erst ab 2019 zur Anwendung kommen.

*Eine ergänzende tabellarische Gegenüberstellung findet sich in den [Tagungsunterlagen](https://www.deutsche-schachjugend.de/fileadmin/dsj_image/wir/Verband/JV_2018/AntraegeJugendversammlung.pdf).*

*Aus Gründen der Einfachheit wurde im GitHub einzig der letztlich beschlossene Änderungsantrag (b) als Commit 6fdfef71af359191178e5cdf2799497a8ad68545 abgebildet.*