### PR TITLE
Überschreiten von Melde- und Zahlungsfristen

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -102,7 +102,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Anträge auf eine Ausnahme von der Verpflichtung, in der vermittelten Unterkunft übernachten zu müssen, werden im Einzelfall geprüft. Der Turnierverantwortliche berücksichtigt bei seiner Entscheidung die Einschätzung des Landesverbands, sofern sie vorliegt. Lehnt der Turnierverantwortliche den Antrag ab und ging er mindestens drei Wochen vor Beginn der Meisterschaft ein, so kann der Antragsteller binnen zwei Wochen die Entscheidung vom geschäftsführenden Vorstand kontrollieren lassen.
 
 1.  
-    Wird eine Meldefrist überschritten, wird schriftlich eine angemessene Nachfrist gesetzt. Bleibt auch die Nachfrist ungenutzt, hat der Turnierverantwortliche in Abstimmung mit dem AKS das Recht, den Platz anderweitig zu vergeben.
+    Wird eine Melde- oder Zahlungsfrist überschritten, wird schriftlich eine angemessene Nachfrist gesetzt. Bleibt auch die Nachfrist ungenutzt, hat der Turnierverantwortliche in Abstimmung mit dem AKS das Recht, den Spieler oder die Mannschaft von der Teilnahme auszuschließen und den Platz anderweitig zu vergeben.
 
 1.  
     Sofern für einzelne Meisterschaften in dieser Spielordnung oder den Ausführungsbestimmungen nichts anderes bestimmt ist, beträgt die Spielzeit 90 Minuten für 40 Züge, danach zusätzliche 30 Minuten für die restlichen Züge, bei zusätzlichen 30 Sekunden pro Zug von Beginn an.


### PR DESCRIPTION
Die Anträge (a) und (b) werden gemeinsam zur Abstimmung gestellt.

## (a) Änderung der Jugendspielordnung
> **JSpO 2.4 (geltende Fassung)**
> Wird eine Meldefrist überschritten, wird schriftlich eine angemessene Nachfrist gesetzt. Bleibt auch die Nachfrist ungenutzt, hat der Turnierverantwortliche in Abstimmung mit dem AKS das Recht, den Platz anderweitig zu vergeben. 
> **JSpO 2.4 (neue Fassung)**
> Wird eine Melde- oder Zahlungsfrist überschritten, wird schriftlich eine angemessene Nachfrist gesetzt. Bleibt auch die Nachfrist ungenutzt, hat der Turnierverantwortliche in Abstimmung mit dem AKS das Recht, den Spieler oder die Mannschaft von der Teilnahme auszuschließen und den Platz anderweitig zu vergeben.

## (b) Änderung der Finanzordnung
> **§ 5.2 (geltende Fassung)**
> Spieler und Mannschaften können von Veranstaltungen der DSJ ausgeschlossen werden, wenn die Fristen oder Stichtage für die Zahlung von Teilnehmerbeträgen nicht eingehalten wurden und vom Finanzreferenten erfolglos eine Nachfrist von 7 Tagen gesetzt wurde. 
> **§ 5.2 (neue Fassung, Änderung hervorgehoben)**
> Personen und Organisationen können von Veranstaltungen der DSJ ausgeschlossen werden, wenn die Fristen oder Stichtage für die Zahlung von Teilnahmebeträgen nicht eingehalten wurden und der Finanzreferent oder ein von ihm beauftragter Vertreter erfolglos eine angemessene Nachfrist gesetzt hat. Bestimmungen der Spielordnung zu Überschreitungen von Zahlungsfristen gehen dieser Regelung vor.

## Begründung

Das Übertreten von Zahlungsfristen ist bislang abschließend in der Finanzordnung geregelt. Dies sorgt dafür, dass etwa bei ausstehenden Reuegeldzahlungen zur DVM Sanktionen nur vom Finanzreferenten ausgesprochen werden können, wenngleich dies im Verantwortungsbereich des Turnierverantwortlichen bzw. AKS liegt. Durch die Änderung soll deutlicher gefasst werden, dass auch Regelungen der Spielordnung zum Ausschluss aufgrund von ausstehenden Teilnahmebeträgen führen können.
Die bislang starre Frist von sieben Tagen aus der Finanzordnung soll der „angemessenen Frist“ aus JSpO 2.4 angeglichen werden.