### PR TITLE
AB 8.2: Empfehlung zur Gestaltung der Regionalgruppenturniere zur DVM

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -378,6 +378,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     Die jeweiligen Landesverbände organisieren den zur Ermittlung der Qualifikanten notwendigen Spielbetrieb in eigener Verantwortung.
 
+    > Sollte eine Regionalgruppe zur Ermittlung der Qualifikanten einer Altersklasse eine Regionalgruppenmeisterschaft ausspielen, so soll diese Meisterschaft mindestens sechs Plätze bieten.
+
 1.  
     Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
 


### PR DESCRIPTION
> **JSpO 8.2 (geltende Fassung, unverändert)**
> Zur Ermittlung der teilnehmenden Mannschaften werden folgende Regionalgruppen gebildet:
> -    Nord: Berlin, Brandenburg, Bremen, Hamburg, Mecklenburg-Vorpommern, Niedersachsen, Sachsen-Anhalt, Schleswig-Holstein;
> -    West: Nordrhein-Westfalen;
> -    Mitte: Hessen, Thüringen, Rheinland-Pfalz, Saarland;
> -    Süd-Ost: Bayern, Sachsen;
> -    Süd: Baden, Württemberg.
> 
> Die jeweiligen Landesverbände organisieren den zur Ermittlung der Qualifikanten notwendigen Spielbetrieb in eigener Verantwortung.
>
> **AB zu 8.2 (neu einzufügen)**
> Sollte eine Regionalgruppe zur Ermittlung der Qualifikanten einer Altersklasse eine Regionalgruppenmeisterschaft ausspielen, so soll diese Meisterschaft mindestens sechs Plätze bieten.

### Begründung

Zur Bestimmung der Qualifikanten zur DVM sind die Landesverbände in fünf Regionalgruppen unterteilt. Diese organisieren den notwendigen Spielbetrieb in eigener Verantwortung.

Aufgrund der unterschiedlichen Größe und Mitgliederzahlen der Landesverbände sind diese Regionalgruppen sehr unterschiedlich charakterisiert: Auf der einen Seite bildet das mitgliederstarke Nordrhein-Westfalen eine eigene Regionalgruppe, auf der anderen Seite umfasst die Regionalgruppe Nord ganze acht Verbände. Da den Regionalgruppen in den verschiedenen DVM-Altersklassen in der Regel stets zwei bis fünf Plätze zustehen, stellt sich mancherorts die Frage, wie eine Hand voll Plätze gerecht auf wenige Landesverbände zu verteilen sind, während es anderenorts gilt, wenige Plätze unter vielen Landesverbänden auszuspielen. Im Detail sind die Qualifikationswege zur DVM derzeit wie folgt:
- Regionalgruppe Nord:
    - U20: Die Regionalgruppe Nord hatte zuletzt stets vier Plätze, die sie gleichmäßig auf ihre beiden Jugendbundesligastaffeln verteilte. In 2018 gibt es nur drei Plätze.
    - Andere Altersklassen: Der Regionalgruppe stehen stets vier bis fünf Plätze zur Verfügung, die sie in Norddeutschen Vereinsmeisterschaften mit stets ca. 16 Teams je Altersklasse ausspielen.
- Regionalgruppe West:
    - U20: NRW spielt eine Jugendbundesliga mit acht Teams aus, von denen sich zuletzt stets drei für die DVM qualifizierten.
    - U16: NRW spielt eine Liga mit zwei Staffeln und jeweils sechs Mannschaften aus, wobei die Erstplatzierten der beiden Gruppen die Qualifikationsplätze zur DVM erhalten. Bei ungerader Platzanzahl findet ein Stichkampf zwischen den Gleichplatzierten der beiden Gruppen statt.
    - Andere Altersklassen: Im Rahmen eines Schnellschachturniers mit ca. 20 Mannschaften aus den Verbänden (u12 und u14) bzw. offen (u14w) qualifizieren sich die besten sechs für eine Endrunde. Diese wird als Vollrundenturnier ausgespielt, hier qualifizieren sich manchmal drei, jedoch vier Mannschaften zur DVM.
- Regionalgruppe Mitte:
    - Alle Altersklassen: Die Regionalgruppe hat in den meisten Altersklassen drei Plätze zu vergeben (ggf. nur zwei in der U20, vier in der U14w) und spielt die Qualifikation mit unterschiedlichen Teilnehmerzahlen aus. Zuletzt mit etwa acht Teams, früher mit nur vier.
- Regionalgruppe Süd-Ost:
    - Alle Altersklassen: Die Regionalgruppe führt keinen gemeinsamen Spielbetrieb, sondern teilt ihre stets vier Qualifikationsplätze gleichmäßig auf die Länder auf. In der U20, wo nur drei Plätze zur Verfügung stehen, findet ein Stichkampf um den dritten Platz statt.
- Regionalgruppe Süd:
    - U20: Die Regionalgruppe Süd hatte zuletzt stets drei Plätze, die sie über die gemeinsame Jugendbundesliga Süd vergibt.
    - Andere Altersklassen: Es wird ein Vollrundenturnier mit sechs Teams ausgespielt, von denen sich drei bis vier qualifizieren.

Der DSJ-Vorstand hält daran fest, dass die Ausgestaltung der Regionalgruppenmeisterschaften den beteiligten Landesverbänden obliegt. Ausgehend von der obigen Übersicht hat sich jedoch herausgestellt, dass sich ein Turnier mit bestenfalls mindestens doppelt so vielen Mannschaften wie Qualifikationsplätzen als sportlich attraktiv darstellt. In jedem Fall soll aber mindestens sechs Mannschaften die Teilnahme ermöglicht werden, um eine sportlich aussagekräftige Meisterschaft, Chancengleichheit und eine große Attraktivität des Qualifikationsturniers sicherzustellen. Dies soll nun auch als Empfehlung in die Ausführungsbestimmungen aufgenommen werden.

Derzeit weicht einzig die Regionalgruppe Mitte in manchen Jahren von der neuen Empfehlung ab, indem sie ein Qualifikationsturnier um die zumeist drei Qualifikationsplätze ausspielt, zu dem jeder der vier Landesverbände eine Mannschaft schickt. Dieses sportlich wenig attraktive Turnier, das einzig dem Ausspielen eines Verlierers dient, sorgte in der Vergangenheit für Wettbewerbsverzerrungen, indem etwa bereits sicher qualifizierte Vereine vorzeitig abreisten. Mit der neuen Empfehlung soll dies vermieden und die Attraktivität der DVM und ihrer Qualifikationsturniere sichergestellt werden.

Verteilt eine Regionalgruppe ihre Qualifikationsplätze bislang aufgrund eines anderen Systems, also ohne eine (einzige) Regionalgruppenmeisterschaft, bleibt dieses System unangetastet. So sind insbesondere die derzeitigen Modi der Regionalgruppen Nord und Süd-Ost von der neuen Ausführungsbestimmung nicht unmittelbar betroffen.