### PR TITLE
AB 8.2: Konfliktbeilegung für die Regionalgruppenturniere zur DVM

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -378,6 +378,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     Die jeweiligen Landesverbände organisieren den zur Ermittlung der Qualifikanten notwendigen Spielbetrieb in eigener Verantwortung.
 
+    > Sofern sich eine Regionalgruppe aus mehreren Landesverbänden zusammensetzt und diese sich nicht auf einen Austragungsmodus zur Ermittlung der Qualifikanten in einer Altersklasse einigen, kann jeder dieser Landesverbände beim Nationalen Spielleiter die verbindliche Festlegung des Austragungsmodus beantragen.
+
 1.  
     Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
 


### PR DESCRIPTION
> **JSpO 8.2 (geltende Fassung, unverändert)**
> Zur Ermittlung der teilnehmenden Mannschaften werden folgende Regionalgruppen gebildet:
> -    Nord: Berlin, Brandenburg, Bremen, Hamburg, Mecklenburg-Vorpommern, Niedersachsen, Sachsen-Anhalt, Schleswig-Holstein;
> -    West: Nordrhein-Westfalen;
> -    Mitte: Hessen, Thüringen, Rheinland-Pfalz, Saarland;
> -    Süd-Ost: Bayern, Sachsen;
> -    Süd: Baden, Württemberg.
> 
> Die jeweiligen Landesverbände organisieren den zur Ermittlung der Qualifikanten notwendigen Spielbetrieb in eigener Verantwortung.
>
> **AB zu 8.2 (neu einzufügen)**
> Sofern sich eine Regionalgruppe aus mehreren Landesverbänden zusammensetzt und diese sich nicht auf einen Austragungsmodus zur Ermittlung der Qualifikanten in einer Altersklasse einigen, kann jeder dieser Landesverbände beim Nationalen Spielleiter die verbindliche Festlegung des Austragungsmodus beantragen.

### Begründung

Die Jugendspielordnung sieht in Ziffer 8.2 vor, dass die Regionalgruppen den notwendigen Spielbetrieb zur Ermittlung der Qualifikanten in eigener Verantwortung gestalten. Der DSJ-Vorstand möchte die Länder auch weiter in dieser Aufgabe bestärken, gleichwohl aber einen Ausweg im Falle der Uneinigkeit bieten: Einigen sich die Länder in einer Altersklasse nicht auf einen gemeinsamen Austragungsmodus, kann der Nationale Spielleiter auf Antrag eines Landesverbandes einen verbindlichen Modus festlegen. Der Nationale Spielleiter wird dabei die Interessen der beteiligten Landesverbände würdigen und sich an den bisherigen Ausrichtungen in dieser Regionalgruppe orientieren. Gegen die Entscheidung des Nationalen Spielleiters kann nach der Rechts- und Verfahrensordnung Protest beim DSJ-Schiedsgericht eingelegt werden, sodass die Entscheidung überprüfbar bleibt.