### PR TITLE
Klarstellung zur Anwendung von Anhang III bei der DVM U10

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -518,7 +518,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U10 nehmen 40 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
-    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang III.4 der FIDE-Regeln findet keine Anwendung.
+    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Es findet Anhang III der FIDE-Regeln ohne III.4 Anwendung.
 
 1.  
     Ziffer 9.2 gilt entsprechend.


### PR DESCRIPTION
> **AB zu 15.1 (geltende Fassung)**
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang III.4 der FIDE-Regeln findet keine
Anwendung.
> **AB zu 15.1 (neue Fassung)**
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Es findet Anhang III der FIDE-Regeln ohne
III.4 Anwendung.

#### Begründung

Gemäß der aktuellen FIDE-Regeln findet Anhang III zur Endspurtphase nur in Turnieren Anwen-
dung, für die dies im Voraus angekündigt wurde. Um dies zu verdeutlichen, wird der Wortlaut in
AB zu 15.1 entsprechend angepasst.