### PR TITLE
Karenzzeitregelung bei der DVM U10

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -520,6 +520,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Anhang III.4 der FIDE-Regeln findet keine Anwendung.
 
+    > Abweichend zu AB zu 2.5 (1) erhält jeder Spieler, der nach der Erklärung des Schiedsrichters, die Runde sei eröffnet (Spielbeginn), im Spielbereich eintrifft, eine Zeitstrafe von 15 Minuten, vorausgesetzt dass dies nicht seine erste Verspätung in diesem Turnier war.
+
 1.  
     Ziffer 9.2 gilt entsprechend.
 


### PR DESCRIPTION
> **AB zu 15.1 (zu ergänzen)**
> Abweichend zu AB zu 2.5 (1) erhält jeder Spieler, der nach der Erklärung des Schiedsrichters, die Runde sei eröffnet (Spielbeginn), im Spielbereich eintrifft, eine Zeitstrafe von 15 Minuten, vorausgesetzt dass dies nicht seine erste Verspätung in diesem Turnier war.

### Begründung

Die Ausführungsbestimmungen zu 2.5 sehen vor, dass Spieler, die sich erstmalig zur Partie verspäten, eine Zeitstrafe von 15 Minuten erhalten, und bei jedem weiteren Zuspätkommen in diesem Turnier ihre Partie verlieren. Wenngleich solche Verspätungen in der DVM U10 sehr selten sind, ist die bislang anzuwendende Zeitstrafe in Anbetracht der Gesamtbedenkzeit von einer Stunde unverhältnismäßig. Zur DVM U10 scheint es ausreichend, erst ab dem zweiten Vergehen vom Bedenkzeitabzug Gebrauch zu machen, und dafür zu keinem Zeitpunkt mit dem Partieverlust zu drohen.