### PR TITLE
Verschieben von AB bzgl. Ahndung regelwidriger Züge von 2.1 nach 15.1

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -85,8 +85,6 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Gemäß Art. 9.1.1 der FIDE-Regeln ist es Spielern ohne Zustimmung des Schiedsrichters nicht gestattet, vor Vollendung des 20. Zuges Remis zu vereinbaren. Umgehen die Spieler diese Regelung, kann dies nach Ziffer 3 bestraft werden.
 
-    > Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
-
 1.  
     Der Schiedsrichter berücksichtigt bei der Anwendung der FIDE-Regeln den Entwicklungsstand des Spielers und kann in begründeten Ausnahmefällen im Sinne einer altersgemäßen Handhabung von einzelnen Regeln abweichende Entscheidungen treffen.
 
@@ -521,6 +519,8 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Es findet Anhang III der FIDE-Regeln ohne III.4 Anwendung.
 
     > Abweichend zu AB zu 2.5 (1) erhält jeder Spieler, der nach der Erklärung des Schiedsrichters, die Runde sei eröffnet (Spielbeginn), im Spielbereich eintrifft, eine Zeitstrafe von 15 Minuten, vorausgesetzt dass dies nicht seine erste Verspätung in diesem Turnier war.
+
+    > Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzuwenden.
 
 1.  
     Ziffer 9.2 gilt entsprechend.


### PR DESCRIPTION
> **AB zu 2.1 [Spielweise, Spielregeln, Streitfälle] (Auszug, geltende Fassung, zu streichen)**
> Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug
die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzu-
wenden.
> **AB zu 15.1 [DVM U10] (neu zu ergänzen)**
> Abweichend von Art. 7.5.5 der FIDE-Regeln verliert ein Spieler erst nach dem dritten regelwidrigen Zug
die Partie. Art. 7.5.5 der FIDE-Regeln ist analog auf den ersten und zweiten regelwidrigen Zug anzu-
wenden.

#### Begründung

Gemäß der aktuellen FIDE-Regeln verliert bereits der zweite regelwidrige Zug die Partie. Die gel-
tende Fassung in AB zu 2.1 ist nicht in Einklang zu bringen mit der gleichermaßen gewünschten
Elo-Auswertung der deutschen Jugendmeisterschaften und beschränkt sich daher fortan einzig
auf die DVM U10, für die vorerst keine Elo-Auswertung angestrebt wird.