### PR TITLE
AB zu 8.3: Zweitmannschaften als Gerademacher zur DVM zulassen

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -381,7 +381,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
 
-    > Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt.
+    > Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern dies zum Erreichen einer geraden Teilnehmerzahl führt.
 
     > Die Hälfte der nach Abzug der Ausrichterfreiplätze zu vergebenden Plätze einer Meisterschaft wird nach der Anzahl der gemeldeten Jugendlichen auf die Regionalgruppen verteilt (Quantität), die andere Hälfte wird nach den Ergebnissen der letzten drei Jahre auf die Regionalgruppen verteilt (Qualität). Das Auf- und Abrunden der Teilnehmerzahlen erfolgt nach der Addition der beiden Kriterien.
     >


### PR DESCRIPTION
> **AB zu JSpO 8.3 (geltende Fassung, Auszug)**
> Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt.
> **AB zu JSpO 8.3 (neue Fassung, Auszug)**
> Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern dies zum Erreichen einer geraden Teilnehmerzahl führt.

#### Begründung

Sagt eine Mannschaft zur DVM nach Meldeschluss ab, wird zuerst ein Nachfolger innerhalb der gleichen Regionalgruppe gesucht und ggf. anschließend der noch freie Platz bundesweit ausgeschrieben. Je nach Zeitpunkt der Absage ist dieses Verfahren jedoch zu langwierig und damit nicht geeignet, das Teilnehmerfeld kurzfristig gerade werden zu lassen. In diesen Fällen sollte dem Ausrichter die Gelegenheit gegeben werden, mit einer zweiten Mannschaft anzutreten. Bislang wurde dies an die Teilnahme am Qualifikationszyklus geknüpft, was jedoch fernab der Praxis ist: Die Ausrichter werden angehalten, sich nicht am Qualifikationszyklus zu beteiligen, um diesen nicht zu verfälschen. Die bislang genannte Bedingung soll daher gestrichen werden.