### PR TITLE
AB zu 15.1: Bedenkzeit DVM U10 auf Inkrement umstellen

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -514,7 +514,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U10 nehmen 40 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
-    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Es findet Anhang III der FIDE-Regeln ohne III.4 Anwendung.
+    > Abweichend von Ziffer 2.5 beträgt die Spielzeit 55 Minuten bei zusätzlichen 5 Sekunden pro Zug von Beginn an.
 
     > Abweichend zu AB zu 2.5 (1) erhält jeder Spieler, der nach der Erklärung des Schiedsrichters, die Runde sei eröffnet (Spielbeginn), im Spielbereich eintrifft, eine Zeitstrafe von 15 Minuten, vorausgesetzt dass dies nicht seine erste Verspätung in diesem Turnier war.
 


### PR DESCRIPTION
> **AB zu JSpO 15.1 (geltende Fassung, Auszug)**
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 60 Minuten. Es findet Anhang III der FIDE-Regeln ohne III.4 Anwendung.
> **AB zu JSpO 15.1 (neue Fassung, Auszug)**
> Abweichend von Ziffer 2.5 beträgt die Spielzeit 55 Minuten bei zusätzlichen 5 Sekunden pro Zug von Beginn an.

#### Begründung

Die DVM U10 ist – mit Ausnahme der Deutschen Schulschachmeisterschaften – die einzige Meisterschaft, die ohne Inkrement ausgespielt wird. Mit der Änderung auf einen Modus mit Inkrement soll verhindert werden, dass eine Partie nicht „schachlich“ beendet werden kann. Eine technisch gewonnene Stellung soll nicht aufgrund mangelnder Zeit Remis oder verloren gegeben werden müssen. Aus diesem Grund wird ein Inkrement von 5 Sekunden pro Zug eingeführt. Zwar war es mit der bisherigen Fassung theoretisch möglich, bei unter 2 Minuten Remis zu reklamieren (Richtlinie III, ehemals FIDE-Regel 10.2), jedoch ist die korrekte Antragsstellung in der U10 nicht zu erwarten.

Um den Zeitbedarf für die Runden nicht zu verändern, wird die Grundbedenkzeit von 60 auf 55 Minuten reduziert. Somit beträgt die Bedenkzeit nach 60 Zügen pro Spieler insgesamt 60 Minuten, während sie bei 120 Zügen auch nur um 5 Minuten pro Spieler erhöht ist. Daher besteht keine große Gefahr, dass durch das Inkrement der Zeitplan des Turniers wesentlich beeinträchtigt wird.

Aufgrund der Umstellung auf einen Modus mit Inkrement findet der Anhang III (Partien ohne Zeitinkrement einschließlich Endspurtphase) keine Anwendung mehr. Da die Bedenkzeit stets auf 60 Züge hochgerechnet wird, gelten weiterhin die Turnierschachregeln und die DWZ-Auswertung wird gewährleistet. Sobald ein Spieler weniger als 5 Minuten hat, ist er gemäß der FIDE-Regeln auch weiterhin von der Mitschreibpflicht entbunden.