### PR TITLE
Teilnahme von internationalen Mannschaften an der DLM 2020

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -331,6 +331,12 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Regionalauswahl gebildet werden. Für die Regionalauswahl sind alle Spieler einer Regionalgruppe nach 8.3 spielberechtigt. Die Regionalauswahl sollte möglichst aus der Region kommen, in der der Ausrichtungsort liegt.
 
+    > Der AKS wird ermächtigt, im Jahr 2020 bis zu 11 Mannschaften aus dem Ausland zur DLM zuzulassen. Die Mannschaften sollen Nationen oder Regionen (vergleichbar den Bundesländern) repräsentieren. Der AKS wird ermächtigt, insoweit von der Spielordnung abzuweichen und mit der Ausschreibung die Teilnahmemodalitäten festzulegen.
+    >
+    > Es wird nur eine Mannschaft pro Landesverband zugelassen. Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Zweitmannschaft eines Landesverbandes zugelassen werden.
+    >
+    > Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind für ausländische Mannschaften alle Jugendlichen, die in der FIDE-Liste der jeweiligen Nation geführt werden oder deren Staatsbürgerschaft besitzen.
+
 1.  
     Bei den DLM sind je Mannschaft nur Spieler startberechtigt, die zum Zeitpunkt der DLM für einen Verein des jeweiligen Landesverbandes spielberechtigt sind. Findet ein Land nicht genügend eigene starke Spieler um die DLM zu beschicken, können Spielgemeinschaften mit bis zu vier Spielern zugelassen werden, die nach Satz 1 für einen anderen Landesverband startberechtigt sind.
 
@@ -345,11 +351,17 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Abweichend zu AB zu 5 wird die Startrangliste nach dem DWZ-Schnitt der acht höchstgesetzten Spieler gebildet, die Ziffer 7.3 Satz 1 erfüllen.
 
+    > Abweichend zu AB zu 5 wird die Startrangliste im Jahr 2020 nach dem Elo-Schnitt der acht höchstgesetzten Spieler gebildet, die Ziffer 7.3 Satz 1 erfüllen; ersatzweise DWZ oder Pseudo-DWZ. AB zu 5.7 Abs. 3 ist analog anzuwenden.
+
 1.  
     Es wird ein Turnier über sieben Runden nach Schweizer System ausgetragen.
 
+    > Im Jahr 2020 wird ein Turnier über neun Runden nach Schweizer System ausgetragen.
+
 1.  
     Der Sieger erhält den Titel "Deutscher Jugendmannschaftsmeister der Länder [Jahreszahl]".
+
+    > Im Jahr 2020 erhält der Sieger den Titel "Internationaler Deutscher Ländermeister 2020".
 
 
 ## 8. Allgemeine Bestimmungen zu den Deutschen Meisterschaften für Vereinsmannschaften

--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -329,13 +329,13 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DLM nehmen Landesverbandsmannschaften teil. Jeder Landesverband kann mindestens eine Mannschaft stellen. Der Ausrichter darf eine weitere Landesauswahl melden.
 
-    > Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Regionalauswahl gebildet werden. Für die Regionalauswahl sind alle Spieler einer Regionalgruppe nach 8.3 spielberechtigt. Die Regionalauswahl sollte möglichst aus der Region kommen, in der der Ausrichtungsort liegt.
+    Der AKS wird ermächtigt, im Jahr 2020 bis zu 11 Mannschaften aus dem Ausland zur DLM zuzulassen. Die Mannschaften sollen Nationen oder Regionen (vergleichbar den Bundesländern) repräsentieren. Der AKS wird ermächtigt, insoweit von der Spielordnung abzuweichen und mit der Ausschreibung die Teilnahmemodalitäten festzulegen.
 
-    > Der AKS wird ermächtigt, im Jahr 2020 bis zu 11 Mannschaften aus dem Ausland zur DLM zuzulassen. Die Mannschaften sollen Nationen oder Regionen (vergleichbar den Bundesländern) repräsentieren. Der AKS wird ermächtigt, insoweit von der Spielordnung abzuweichen und mit der Ausschreibung die Teilnahmemodalitäten festzulegen.
-    >
-    > Es wird nur eine Mannschaft pro Landesverband zugelassen. Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Zweitmannschaft eines Landesverbandes zugelassen werden.
-    >
-    > Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind für ausländische Mannschaften alle Jugendlichen, die in der FIDE-Liste der jeweiligen Nation geführt werden oder deren Staatsbürgerschaft besitzen.
+    Es wird nur eine Mannschaft pro Landesverband zugelassen. Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Zweitmannschaft eines Landesverbandes zugelassen werden.
+    
+    Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind für ausländische Mannschaften alle Jugendlichen, die in der FIDE-Liste der jeweiligen Nation geführt werden oder deren Staatsbürgerschaft besitzen.
+
+    > Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Regionalauswahl gebildet werden. Für die Regionalauswahl sind alle Spieler einer Regionalgruppe nach 8.3 spielberechtigt. Die Regionalauswahl sollte möglichst aus der Region kommen, in der der Ausrichtungsort liegt.
 
 1.  
     Bei den DLM sind je Mannschaft nur Spieler startberechtigt, die zum Zeitpunkt der DLM für einen Verein des jeweiligen Landesverbandes spielberechtigt sind. Findet ein Land nicht genügend eigene starke Spieler um die DLM zu beschicken, können Spielgemeinschaften mit bis zu vier Spielern zugelassen werden, die nach Satz 1 für einen anderen Landesverband startberechtigt sind.
@@ -356,12 +356,12 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     Es wird ein Turnier über sieben Runden nach Schweizer System ausgetragen.
 
-    > Im Jahr 2020 wird ein Turnier über neun Runden nach Schweizer System ausgetragen.
+    Im Jahr 2020 wird ein Turnier über neun Runden nach Schweizer System ausgetragen.
 
 1.  
     Der Sieger erhält den Titel "Deutscher Jugendmannschaftsmeister der Länder [Jahreszahl]".
 
-    > Im Jahr 2020 erhält der Sieger den Titel "Internationaler Deutscher Ländermeister 2020".
+    Im Jahr 2020 erhält der Sieger den Titel "Internationaler Deutscher Ländermeister 2020".
 
 
 ## 8. Allgemeine Bestimmungen zu den Deutschen Meisterschaften für Vereinsmannschaften


### PR DESCRIPTION
> **JSpO 7.1 (geltende Fassung)**
> An der DLM nehmen Landesverbandsmannschaften teil. Jeder Landesverband kann mindestens eine Mannschaft stellen. Der Ausrichter darf eine weitere Landesauswahl melden.
> **Ergänzung zu JSpO 7.1 für die DLM 2020**
> Der AKS wird ermächtigt, im Jahr 2020 bis zu 11 Mannschaften aus dem Ausland zur DLM zuzulassen. Die Mannschaften sollen Nationen oder Regionen (vergleichbar den Bundesländern) repräsentieren. Der AKS wird ermächtigt, insoweit von der Spielordnung abzuweichen und mit der Ausschreibung die Teilnahmemodalitäten festzulegen.
> Es wird nur eine Mannschaft pro Landesverband zugelassen. Zur Vermeidung einer ungeraden Teilnehmerzahl kann nach Ablauf der Meldefrist eine Zweitmannschaft eines Landesverbandes zugelassen werden.
> Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind für ausländische Mannschaften alle Jugendlichen, die in der FIDE-Liste der jeweiligen Nation geführt werden oder deren Staatsbürgerschaft besitzen.

> **AB zu JSpO 7.3 (geltende Fassung)**
> Abweichend zu AB zu 5 wird die Startrangliste nach dem DWZ-Schnitt der acht höchstgesetzten Spieler gebildet, die Ziffer 7.3 Satz 1 erfüllen.
> **Ergänzung zu AB zu JSpO 7.3 für die DLM 2020**
> Abweichend zu AB zu 5 wird die Startrangliste im Jahr 2020 nach dem Elo-Schnitt der acht höchstgesetzten Spieler gebildet, die Ziffer 7.3 Satz 1 erfüllen; ersatzweise DWZ oder Pseudo-DWZ. AB zu 5.7 Abs. 3 ist analog anzuwenden.

> **JSpO 7.4 (geltende Fassung)**
> Es wird ein Turnier über sieben Runden nach Schweizer System ausgetragen.
> **Ergänzung zu JSpO 7.4 für die DLM 2020**
> Im Jahr 2020 wird ein Turnier über neun Runden nach Schweizer System ausgetragen. 

> **JSpO 7.5 (geltende Fassung)**
> Der Sieger erhält den Titel „Deutscher Jugendmannschaftsmeister der Länder [Jahreszahl]“.
> **Ergänzung zu JSpO 7.5 für die DLM 2020**
> Im Jahr 2020 erhält der Sieger den Titel „Internationaler Deutscher Ländermeister 2020“.

#### Begründung

Im Jahr 2020 feiert die Deutsche Schachjugend ihr 50-jähriges Bestehen. Im Rahmen dieses Jubiläums finden über das gesamte Jahr hinweg Veranstaltungen statt; bestehende Veranstaltungen sollen wo möglich durch einmalige Gestaltung zur Feier des Jubiläums beitragen. 
Der Arbeitskreis Spielbetrieb (AKS) plant, die Deutsche Ländermeisterschaft (DLM) im Jahr 2020 einmalig mit einer großen internationalen Beteiligung auszutragen. Im Oktober 2018 hat der AKS hierüber in einem Rundschreiben an die Länder informiert und ausschließlich positive Rückmeldungen erhalten. Eine aktualisierte Fassung der skizzierten Überlegungen findet sich ebenfalls in dieser Broschüre, sodass hierauf verwiesen wird. Im Folgenden wird daher einzig auf Ausgestaltungsdetails eingegangen.

**Zur Ergänzung zu JSpO 7.1:** Die ausländischen Mannschaften sollen zeitnah eingeladen werden, sodass bis zur Jugendversammlung 2020 die Zusagen feststehen. Sollte sich abzeichnen, dass nur wenige Länder teilnehmen möchten, kann noch zur Jugendversammlung 2020 die Teilnahme von Zweitmannschaften der Landesverbände diskutiert werden.
**Zur Ergänzung zu AB zu JSpO 7.3:** Da die Jugendlichen eingeladener Mannschaften überwiegend über keine DWZ verfügen dürften, soll zur DLM 2020 abweichend überall auf Elo, ersatzweise DWZ und Pseudo-DWZ abgestellt werden. Dies gilt analog für die Prüfung der 200-Punkte-Regelung aus AB 5.7.
**Zur Ergänzung zu JSpO 7.4:** Da das Turnier voraussichtlich mehr als 20 Mannschaften umfasst, findet AB zu 5.9 keine Anwendung; im Falle mehrerer Mannschaften desselben Landesverbandes müssten diese somit nicht in der 1. Runde gegeneinander gepaart werden.