### PR TITLE
Zulassen von Zweitmannschaften zur DVM U14w

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -479,6 +479,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 1.  
     An der DVM U14w nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U14.
 
+1.
+    Ziffer 8.4 findet keine Anwendung.
+
 1.  
     In jeder Mannschaft ist abweichend von Ziffer 8.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, sofern dieser dem Gastspiel zustimmt. Sie darf zudem im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet worden sein.
 


### PR DESCRIPTION
> **JSpO 13.2 (neu einzufügen)**
> Ziffer 8.4 findet keine Anwendung. 
> **Die nachfolgenden Punkte verschieben sich entsprechend.**

#### Begründung

Im Allgemeinen ist bei den DVM je Altersklasse nur eine Mannschaft pro Verein startberechtigt. Für die offene DVM U20w ist diese Beschränkung bereits seit einiger Zeit aufgehoben. Auch für die DVM U14w soll es künftig Vereinen ermöglicht werden, sich mit mehreren Mannschaften zur Teilnahme zu qualifizieren. In diesem Fall werden die entsprechenden Mannschaften gemäß AB zu JSpO 5.9 in möglichst früher Runde gegeneinander gepaart.