### PR TITLE
Freiplätze zur DVM

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -379,7 +379,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     > Sofern sich eine Regionalgruppe aus mehreren Landesverbänden zusammensetzt und diese sich nicht auf einen Austragungsmodus zur Ermittlung der Qualifikanten in einer Altersklasse einigen, kann jeder dieser Landesverbände beim Nationalen Spielleiter die verbindliche Festlegung des Austragungsmodus beantragen.
 
 1.  
-    Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
+    Der Ausrichter erhält einen Freiplatz, es können bis zu zwei weitere Freiplätze vergeben werden. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen.
+
+    > Die Freiplätze vergibt der Spielausschuss.
 
     > Der Ausrichter kann mit einer zweiten Mannschaft starten, sofern eine Mannschaft des ausrichtenden Vereins bereits qualifiziert ist und dies zum Erreichen einer geraden Teilnehmerzahl führt.
 
@@ -527,7 +529,9 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U10 [Jahreszahl]".
 
 1.  
-    Abweichend zu 8.2 und 8.3 ergibt sich das Teilnehmerfeld wie folgt: Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Landesverbände verteilt. Das Nähere regeln die Ausführungsbestimmungen.
+    Abweichend zu 8.2 und 8.3 ergibt sich das Teilnehmerfeld wie folgt: Der Ausrichter erhält einen Freiplatz, es können bis zu vier weitere Freiplätze vergeben werden. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Landesverbände verteilt. Das Nähere regeln die Ausführungsbestimmungen.
+
+    > Die Freiplätze vergibt der Spielausschuss.
 
     > AB zu 8.3 gilt entsprechend für die Landesverbände.
 


### PR DESCRIPTION
> **JSpO 8.3 (geltende Fassung)**
> Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen.
> **JSpO 8.3 (neue Fassung)**
> Der Ausrichter erhält einen Freiplatz, es können bis zu zwei weitere Freiplätze vergeben werden. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Regionalgruppen verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
> **AB zu JSpO 8.3 (Auszug, zu ergänzen)**
> Die Freiplätze vergibt der Spielausschuss.

> **JSpO 15.4 (geltende Fassung)**
> Abweichend zu 8.2 und 8.3 ergibt sich das Teilnehmerfeld wie folgt: Der Ausrichter erhält einen Freiplatz. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Landesverbände verteilt. Das Nähere regeln die Ausführungsbestimmungen.
> **JSpO 15.4 (neue Fassung)**
> Abweichend zu 8.2 und 8.3 ergibt sich das Teilnehmerfeld wie folgt: Der Ausrichter erhält einen Freiplatz, es können bis zu vier weitere Freiplätze vergeben werden. Die übrigen Teilnehmerplätze werden zu gleichen Teilen nach Qualität (Erfolge der vergangenen drei Jahre) und Quantität auf die Landesverbände verteilt. Das Nähere regeln die Ausführungsbestimmungen. 
> **AB zu JSpO 15.4 (Auszug, zu ergänzen)**
> Die Freiplätze vergibt der Spielausschuss.

#### Begründung

Analog zur DEM sollen in jeder DVM-Altersklasse neben dem Ausrichterfreiplatz zwei weitere Freiplätze durch den Spielausschuss vergeben werden. Die über die Regionalgruppen zu verteilenden Plätze verringern sich damit von 19 auf 17 in den DVM U12, U14, U14w und U16; von 15 auf 13 in der DVM U20, sowie von 39 auf 35 in der DVM U10. Als Prozedere schlagen wir vor:
- Anfang des Jahres werden die DVM-Ausrichter bekanntgegeben. Von ihnen erhält jeder einen Freiplatz in seiner Altersklasse.
- Anfang des Jahres wird die Verteilung der Qualifikationsplätze auf die Regionalgruppen gemäß der Ausführungsbestimmungen bekanntgegeben. Diese Berechnung basiert auch weiterhin auf Qualität und Quantität.
- Die Regionalgruppen melden bis zum 1. Oktober ihre Qualifikanten.
- Bis zum 1. Oktober können bei der DSJ Freiplatzanträge von Vereinen gestellt werden, die die Qualifikation über das reguläre Teilnahmekontingent verpasst haben oder denen eine Teilnahme am Qualifikationsturnier nicht möglich war.
- Zeitnah, spätestens jedoch bis 15. Oktober, werden die zwei Freiplatzempfänger je Altersklasse bekanntgegeben.
- Bis zum 1. November erklären die qualifizierten Vereine gegenüber der DSJ verbindlich ihre Teilnahme. Nimmt ein Verein seinen Platz nicht wahr, erhält die Regionalgruppe bis zum 10. November Gelegenheit, diesen Platz zu besetzen (wenn gewünscht auch unter Nutzung der Liste der bei der DSJ eingegangenen Freiplatzanträge).
- Nach dem 10. November freigebliebene Plätze werden an die Nachrücker aus der Freiplatzliste vergeben.

Der Vorschlag adressiert vier der bisherigen Probleme:
1. Die bisherige Berechnung der Kontingente deckt nicht jeden Einzelfall ab. Insbesondere werden aktuelle Entwicklungen, bspw. eine besonders große Leistungsdichte in einer einzelnen Altersklasse und Regionalgruppe, nicht genügend gewürdigt. Über die Freiplatzvergabe kann hier entgegengesteuert werden.
2. Aktuell finden Härtefälle keine besondere Beachtung, da es bislang keine Möglichkeit gab, Mannschaften noch über einen Freiplatz zur DVM zuzulassen.
3. Die Suche nach potenziellen Nachrückern im Falle einer kurzfristigen Absage gestaltet sich sehr viel einfacher. Sagt aktuell eine Mannschaft nach Meldeschluss (bisher zwischen 1. und 15. November) ab, so wird zunächst innerhalb der Regionalgruppe nach einem interessierten Nachrücker gesucht und anschließend der Platz bundesweit ausgeschrieben. Durch das Freiplatzverfahren könnte bereits Anfang Oktober eine Liste potenzieller Nachrücker gebildet werden. Ein Listenplatz 3 hätte so Chancen, noch ins Feld nachzurücken, und könnte sich so den Weihnachtstermin zumindest bis Mitte November noch freihalten.
4. Wir möchten Mädchenmannschaften motivieren, sich für die Freiplätze zu bewerben und langfristig mit der Chance der Teilnahme zu planen. Aktuell bleiben insbesondere Plätze der DVM U14w unbesetzt, da es hier schwerer möglich ist, noch kurzfristig Anfang Dezember eine Mannschaft zu finden. Hier birgt die Nachrückerliste die Chance, die DVM U14w auf lange Sicht mit dem vollen 20er-Feld auszuspielen.

Die Freiplätze vergibt der Spielausschuss, der sich aus den beiden Spielleitern sowie einem weiteren AKS-Mitglied zusammensetzt. Dabei werden unter anderem die voraussichtliche Mannschaftsaufstellung sowie das Abschneiden im Qualifikationszyklus berücksichtigt.  Aus den Mannschaften, die keinen Freiplatz erhalten, wird nach den gleichen Kriterien eine Nachrückerliste gebildet, die bei späteren Absagen kurzfristig genutzt werden kann. Auf eine spätere Ausschreibung von DVM-Freiplätzen, wie in der Vergangenheit häufig erst Ende November möglich, kann so verzichtet werden.