### PR TITLE
Bedenkzeit Schulschach - Antrag der Schachjugend in Berlin JHV 2020

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -541,7 +541,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > Der Spielbereich ist für Betreuer und Zuschauer nicht zugänglich. Der Ausrichter sorgt für eine entsprechende Absperrung.
 
-1.  Die Spielzeit beträgt je Spieler eine Stunde für die gesamte Partie, in der WK IV, WK HR und in der WK G 30 Minuten pro Spieler.
+1.  Die Spielzeit beträgt je Spieler 50 Minuten bei zusätzlichen 10 Sekunden pro Zug für die gesamte Partie, in der WK IV, WK HR und in der WK G 30 Minuten pro Spieler.
 
 1.  Der Referent für Schulschach hat in Zusammenarbeit mit dem Arbeitskreis Schulschach das Recht, für die einzelnen Wettkampfklassen Regelungen und Richtlinien zur Durchführung festzulegen und in einzelnen Fällen Sonderregelungen zu treffen; dabei kann von Regelungen der Ziffer 5, nicht aber von Regelungen und Ausführungsbestimmungen der Ziffern 16.1 bis 16.7 abgewichen werden. Alle Festlegungen sind mit den Ausschreibungen der Wettkampfklassen rechtzeitig zu veröffentlichen.
 


### PR DESCRIPTION
Begründung: Das Spielen mit Inkrement ist dank digitaler Uhren inzwischen den meisten Spielern geläufiger und weit verbreitet. Auch die Deutschen Jugendeinzel-, Vereins- und Ländermeisterschaften werden mit Inkrement gespielt. Die Gründe dafür liegen auf der Hand: Es gewinnt der Spieler mit der besseren Stellung und nicht derjenige, der es schafft den Gegner trotz weniger Materials oder schlechterer Stellung noch über die Zeit zu ziehen. Auch werden v.a. die Schiedsrichter entlastet, da es bei Zeitnotschlachten nicht mehr zu Anträgen nach Richtlinie III kommen kann. Für Spannung ist weiterhin gesorgt, allerdings werden Partien nun eher auf dem Brett entschieden, weniger mit der Uhr und nicht mehr durch die Schachregeln.
Da erscheint es sinnvoll, dass auch die DSSM der älteren Wertungsklassen auf Spielen mit Inkrement umstellt. Dabei orientiert sich die hier beantragte Spielzeit insgesamt ungefähr an der bisherigen Gesamtspielzeit. Die FIDE-Regeln decken bereits ab, dass ein Spieler nach Unterschreiten von 5 min Restbedenkzeit nicht mehr mitschreiben muss, auch wenn er durch Inkrement wieder auf über 5 min gelangt (FIDE-Regel, Artikel 8.4).