### PR TITLE
Korrektur Sonderregelungen DVM U10

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -473,7 +473,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
 
-1.  An der DVM U10 nehmen 40 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
+1.  An der DVM U10 nehmen 40 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U10. Teilnahmeberechtigt im Sinne von 1.4 Satz 2 Nr. 4 und startberechtigt abweichend von 8.1 sind alle Jugendlichen, die in der laufenden Saison für diesen Verein spielberechtigt sind.
 
     > Abweichend von Ziffer 2.5 beträgt die Spielzeit 55 Minuten bei zusätzlichen 5 Sekunden pro Zug von Beginn an.
 


### PR DESCRIPTION
Im Zuge der Vorbereitung zur diesjährigen U10 Meisterschaft haben die Schach- freunde des Hamburger Schachjugendbundes korrekterweise darauf hingewiesen, dass die Sonderregelung zur Spielberechtigung für die DVM U10 unklar formuliert ist.
Im Antrag von 2015 zur Öffnung der Teilnahmeberechtigung für die DVM U10 unab- hängig von der Staatsbürgerschaft oder dem Lebensmittelpunkt wurde versäumt, die vorherige explizite Ausnahmeregelung zur Spielberechtigung beizubehalten. Dies soll durch diesen Einschub korrigiert werden.
Die Historie ist einsehbar im Github Repository der Schachjugend: https://github.com/Schachjugend/Spielordnung/pull/18.
Dieser Korrekturantrag dient somit lediglich der Klarstellung der bisherigen aufgrund der Ordnungshistorie angewandten Praxis.