### PR TITLE
Einführung DVM U16w und U12w - Streichung DVM U14w

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -25,9 +25,10 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     *   Deutsche Meisterschaft für Vereins-Jugendmannschaften (DVM U20),
     *   Deutsche Meisterschaft für Vereinsmannschaften der weiblichen Jugend (DVM U20w),
     *   Deutsche Meisterschaft für Vereinsmannschaften der Jugend unter 16 Jahren (DVM U16),
+    *	Deutsche Meisterschaft für Vereinsmannschaften der weiblichen Jugend unter 16 Jahren (DVM U16w),
     *   Deutsche Meisterschaft für Vereinsmannschaften der Jugend unter 14 Jahren (DVM U14),
-    *   Deutsche Meisterschaft für Vereinsmannschaften der weiblichen Jugend unter 14 Jahren (DVM U14w),
     *   Deutsche Meisterschaft für Vereinsmannschaften der Jugend unter 12 Jahren (DVM U12),
+    *   Deutsche Meisterschaft für Vereinsmannschaften der weiblichen Jugend unter 12 Jahren (DVM U12w),
     *   Deutsche Meisterschaft für Vereinsmannschaften der Jugend unter 10 Jahren (DVM U10),
     *   Deutsche Schulschach-Mannschaftsmeisterschaften (DSM).
 
@@ -427,23 +428,11 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
 1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U16 [Jahreszahl]".
 
-
-## 12. DVM U14
+## 12. DVM U16w
 
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 1000.
 
-1.  An der DVM U14 nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U14.
-
-1.  Ziffer 9.2 gilt entsprechend.
-
-1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U14 [Jahreszahl]".
-
-
-## 13. DVM U14w
-
-> Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 800.
-
-1.  An der DVM U14w nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U14.
+1.  An der DVM U16w nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U16.
 
 1.  Ziffer 8.4 findet keine Anwendung.
 
@@ -455,8 +444,17 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
 1.  Ziffer 9.2 gilt entsprechend.
 
-1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der weiblichen Jugend U14 [Jahreszahl]".
+1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der weiblichen Jugend U16 [Jahreszahl]".
 
+## 13. DVM U14
+
+> Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 1000.
+
+1.  An der DVM U14 nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier Jugendlichen der Altersklasse U14.
+
+1.  Ziffer 9.2 gilt entsprechend.
+
+1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U14 [Jahreszahl]".
 
 ## 14. DVM U12
 
@@ -468,8 +466,25 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
 1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der Jugend U12 [Jahreszahl]".
 
+## 15. DVM U12w
 
-## 15. DVM U10
+> Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
+
+1.  An der DVM U12w nehmen 20 Vereinsmannschaften teil. Jede Mannschaft besteht aus vier weiblichen Jugendlichen der Altersklasse U12.
+
+1.  Ziffer 8.4 findet keine Anwendung.
+
+1.  In jeder Mannschaft ist abweichend von Ziffer 8.1 eine Spielerin startberechtigt, die in der der DVM vorangegangenen Saison einem anderen Verein angehörte, sofern dieser dem Gastspiel zustimmt. Sie darf zudem im Qualifikationszyklus zu dieser DVM - gleich auf welcher Ebene - nicht zuvor für diesen anderen oder einen dritten Verein gemeldet worden sein.
+
+    > Die Gastspielgenehmigung gilt als erteilt, falls der abgebende Verein mit keiner eigenen Mannschaft an einer Altersklasse dieser DVM teilnimmt, für die die Spielerin spielberechtigt ist.
+
+    > Eine Spielerin, die in der vergangenen Saison für einen anderen Verein spielberechtigt war und nun zu dem Verein gewechselt ist, für den sie bei der DVM eingesetzt werden soll, ist gleichwohl nur als Gastspielerin startberechtigt.
+
+1.  Ziffer 9.2 gilt entsprechend.
+
+1.  Der Sieger erhält den Titel "Deutscher Vereinsmeister der weiblichen Jugend U12 [Jahreszahl]".
+
+## 16. DVM U10
 
 > Die Pseudo-Wertungszahl für Spieler ohne DWZ und Elo beträgt 600.
 
@@ -491,7 +506,7 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
 
     > AB zu 8.3 gilt entsprechend für die Landesverbände.
 
-## 16. DSM
+## 17. DSM
 
 1.  Die DSM werden jährlich in fünf Wettkampfklassen (WK) ausgetragen. Teilnahmeberechtigt sind allgemein- und berufsbildende Schulen außer Institutionen, die überwiegend der Erwachsenenbildung dienen.
 


### PR DESCRIPTION
Der Arbeitskreis Spielbetrieb hat sich schon länger mit der Thematik der weiblichen DVMs beschäftigt. Zunächst war es eher die U20w, die weniger teilnehmende Teams hatte und in den letzten Jahren die U14w. Im Zuge der DVM 2019 haben wir die teilnehmenden Verein der weiblichen Altersklassen befragt, wie sie zu einer Umstrukturierung der weiblichen Meisterschaften stehen und haben überwiegend positive Rückmeldungen zu den beantragten Änderungen erhalten.
Bei einer Analyse der Turniere sowie der Mitgliederzahlen sind wir zu folgenden Erebnissen gekommen:
Die aktuelle Anzahl an Mädchen/Frauen nimmt mit dem Alter stetig ab. Während es in der Gruppe unter 12 Jahren noch über 2000 Mädchen gibt, sieht man wie in den Folgejahren die Jahrgänge mehr abnehmen.
In der U14w spielen bereits jetzt schon viele U12-Spielerinnen sowie einige U10 Spielerinnen. Diese Zahlen möchte der AKS durch die Neuregelung gerne erhöhen.
Hier sieht man, dass mit 10 U20w Teams (älteste Spielerin war U20) und 20 U16w Teams bereits eigene DVMs durchgeführt werden können. In der U14w sind auch 3 reine U12w Teams an den Start gegangen. Hier erhoffen wir uns durch die Neuregelung, dass die Anzahl U10w und U12w Teams steigt, da der Altersunterschied nicht mehr so hoch ist.
Zusammengefasste Gründe für die neue Aufteilung in drei Altersklassen:
Der Alterssprung zwischen U16w und U20w ist nicht so groß wie zwischen U14w und U20w. Mädchen, die gerade aus der U14w herausgewachsen sind, trauen sich oft nicht in der U20w mitzuspielen, da die Gegnerinnen manchmal bis zu 5 Jahre älter sind.
Die Neueinführung der U12w ermöglicht auch jüngeren Teams die Teilnahme an der Meisterschaft. In den letzten Jahren ist die Anzahl jüngerer Spielerinnen angewachsen. Manche Landesverbände tragen auch bereits U10w und U12w Meisterschaften aus. Allerdings trauen sich die Mädchen aus diesen Mannschaften dann oft nicht an der DVM U14w teilzunehmen. Mit der Änderung von U14w auf U12w erhoffen wir uns, dass mehr jüngere Teams an der DVM teilnehmen.
U10w oder U12w Mädchen haben oft Angst gegen Ältere zu spielen oder sich zu blamieren, da sie eventuell noch nicht so gut sind, oder noch nicht so lange Schach spie- len. Diese Ängste sollen durch das Absenken der Altersklasse abgebaut werden.
Die Mädchen können schon in jüngerem Alter an der DVM teilnehmen. So können sich in den Vereinen schönen früher Mädchenmannschaften bilden, die dann langfristig als Mannschaft zusammen bleibt. Je früher diese Teambildung stattfindet, desto eher blei- ben die Mädchen dann auch als Team zusammen und verlassen den Verein nicht.
Eine frühere Teilnahme an einer Deutschen Meisterschaft in einer geeigneten Altersgruppen stärkt die Bindung an den Verein und fördert das Mädchenschach in Deutschland.
An der DVM U10 2019 haben über 20 Mädchen aufgeteilt auf die verschiedenen Teams teilgenommen. Es gab sogar eine reine Mädchenmannschaft. In der U12 haben 2019 nur 2 Mädchen mitgespielt. Diese Teilnahmen zeigen bereits, dass Mädchen auch im jüngeren Alter an der DVM teilnehmen.
Insbesondere im Grundschulalter ist die Anzahl schachspielender Mädchen noch sehr hoch. Daher wollen wir gerne eine passende Meisterschaft für diese Altersklasse anbieten.