### PR TITLE
JV 2021: Flexibilisierung der DEM-Feldgröße

### DIFF
--- a/Spielordnung.md
+++ b/Spielordnung.md
@@ -286,15 +286,17 @@ Diese Jugendspielordnung wurde von der Jugendversammlung der Deutschen Schachjug
     >
     > *Übergangsbestimmung in Folge der Trennung in U12/U12w sowie U10/U10w: Zur Berechnung werden alle Jungen der U12, alle Mädchen der U12w zugeordnet; entsprechendes für die U10.*
 
-1.  In den Altersklassen U14, U12, U12w, U10 und U10w erhalten alle Kaderspieler in ihrer jeweiligen Altersklasse einen Freiplatz.
+1.  Kaderspieler des Deutschen Schachbundes erhalten in ihrer jeweiligen Altersklasse einen Startplatz. 
 
-    Es können jeweils bis zu elf weitere Freiplätze vergeben werden. Der AKS kann das Freiplatzkontingent bei außergewöhnlichen Umständen um jeweils bis zu vier weitere Freiplätze erhöhen.
-    
-    > Der AKS kann das Freiplatzkontingent erhöhen, wenn in einem Jahr eine außergewöhnlich hohe Zahl von starken Spielern in der jeweiligen Altersklasse zusammenkommt. Eine außergewöhnlich hohe Zahl liegt jedenfalls dann vor, wenn die Zahl der Kaderspieler der Zahl der ordentlichen Freiplätze entspricht oder diese übersteigt.
+    Je Altersklasse werden bis zu acht Freiplätze vergeben. Wenn ein Landesverband auf Qualifikationsplätze gemäß 6.3 bzw. 6.4 verzichtet, kann der AKS die Anzahl der Freiplätze entsprechend erhöhen. 
 
-    > Der DBSB kann in den Altersklassen U18, U18w, U16, U16w und U14w je einen, in den Altersklassen U14, U12, U12w, U10 und U10w je zwei Freiplatzkandidaten nominieren. Dem Freiplatzantrag ist zu entsprechen, wenn die Spielstärke des Kandidaten dem Leistungsniveau der DEM der jeweiligen Altersklasse angemessen ist. Die Entscheidung hierüber trifft der Vorstand. Ein so vergebener Freiplatz zählt bei der Entscheidung des AKS über die Erhöhung des Freiplatzkontingents nicht als ordentlicher Freiplatz.
+    Bei außergewöhnlichen Umständen kann der AKS die Anzahl der Freiplätze um bis zu vier erhöhen. 
 
-    > Die weiteren Freiplätze vergeben der zuständige Nationale Spielleiter und der Beauftragte für Leistungssport auf Vorschlag des Bundesnachwuchstrainers.
+    > Ein außergewöhnlicher Umstand im Sinne von JSpO 6.5 liegt jedenfalls dann vor, wenn in einer Altersklasse besonders viele starke Spieler einen Freiplatz erhalten. 
+
+    > Der DBSB kann in den Altersklassen U18, U18w, U16, U16w und U14w je einen, in den Altersklassen U14, U12, U12w, U10 und U10w je zwei Freiplatzkandidaten nominieren. Diese erhalten einen Startplatz, wenn ihre Spielstärke dem Leistungsniveau der DEM der jeweiligen Altersklasse angemessen ist. Die Entscheidung obliegt dem Spielausschuss.    
+
+    > Freiplätze werden durch ein Gremium, bestehend aus dem zuständigen Nationalen Spielleiter, dem Beauftragten für Leistungssport und dem Bundesnachwuchstrainer, vergeben. 
 
 1.  Der Sieger erhält den Titel "Deutscher Jugendmeister [jeweilige Altersklasse] [Jahreszahl]" bzw. "Deutsche Jugendmeisterin [jeweilige Altersklasse] [Jahreszahl]".
 


### PR DESCRIPTION
Begründung: 

Durch 6.1 werden Anforderungen an die Teilnehmerfelder gestellt, die sich nicht immer erfüllen lassen. Gibt es in einer Altersklasse mehrere Kaderspieler, so reduziert sich die Anzahl der möglichen Freiplätze. Zukünftig sollen die Kaderspieler und die Nominierten des DBSB keinen Einfluss auf die Freiplatzvergabe haben.

Die Reduktion der Freiplatzanzahl von „bis zu elf“ auf „bis zu acht“ ist keine echte
Verknappung. Die Maximalanzahl von derzeit elf ist ohnehin theoretischer Natur, da
sie nicht mit der maximalen Feldgröße in Einklang zu bringen ist.

Wir halten es für gerecht, dass auch in den Altersklassen U18, U18w, U16, U16w und
U14w die Kaderzugehörigkeit automatisch zu einer Teilnahmeberechtigung bei der
DEM führt. Es ist sehr ungewöhnlich, dem DSJ-Vorstand die Entscheidung über die Nominierung des DSBS zu übertragen. Der Spielausschuss ist näher am Spielgeschehen. Dass der Nationale Spielleiter, der Beauftragte für Leistungssport und der Bundesnachwuchstrainer gemeinsam die Freiplatzvergabe durchführen, ist gängige Praxis.

Der Bundesnachwuchstrainer nimmt hierbei kein exklusives Vorschlagsrecht für sich
in Anspruch.